### PR TITLE
Update flags for PendingIntents

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
@@ -37,6 +37,9 @@ import static com.mapbox.services.android.navigation.v5.utils.time.TimeFormatter
 class MapboxNavigationNotification implements NavigationNotification {
 
   private static final String END_NAVIGATION_ACTION = "com.mapbox.intent.action.END_NAVIGATION";
+  final int intentFlag = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ? 
+            PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE : 
+            PendingIntent.FLAG_UPDATE_CURRENT;
   private NotificationCompat.Builder notificationBuilder;
   private NotificationManager notificationManager;
   private Notification notification;
@@ -142,7 +145,7 @@ class MapboxNavigationNotification implements NavigationNotification {
     PackageManager pm = context.getPackageManager();
     Intent intent = pm.getLaunchIntentForPackage(context.getPackageName());
     intent.setPackage(null);
-    return PendingIntent.getActivity(context, 0, intent, 0);
+    return PendingIntent.getActivity(context, 0, intent, intentFlag);
   }
 
   private void registerReceiver(Context context) {
@@ -235,7 +238,7 @@ class MapboxNavigationNotification implements NavigationNotification {
 
   private PendingIntent createPendingCloseIntent(Context context) {
     Intent endNavigationBtn = new Intent(END_NAVIGATION_ACTION);
-    return PendingIntent.getBroadcast(context, 0, endNavigationBtn, 0);
+    return PendingIntent.getBroadcast(context, 0, endNavigationBtn, intentFlag);
   }
 
   private void onEndNavigationBtnClick() {


### PR DESCRIPTION
For Android 31+ we need to specify. the mutability of PendingIntents.

`Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.`

See for example here:https://stackoverflow.com/questions/67045607/how-to-resolve-missing-pendingintent-mutability-flag-lint-warning-in-android-a