### PR TITLE
Resume simulation for multi leg routes

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/location/replay/ReplayRouteLocationConverter.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/location/replay/ReplayRouteLocationConverter.java
@@ -51,6 +51,10 @@ class ReplayRouteLocationConverter {
         return mockedLocations;
     }
 
+    boolean isMultiLegRoute() {
+        return route.legs().size() > 1;
+    }
+
     void initializeTime() {
         time = System.currentTimeMillis();
     }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/location/replay/ReplayRouteLocationEngine.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/location/replay/ReplayRouteLocationEngine.java
@@ -100,8 +100,12 @@ public class ReplayRouteLocationEngine implements LocationEngine, Runnable {
     public void run() {
         List<Location> nextMockedLocations = converter.toLocations();
         if (nextMockedLocations.isEmpty()) {
-            handler.removeCallbacks(this);
-            return;
+            if (converter.isMultiLegRoute()) {
+                nextMockedLocations = converter.toLocations();
+            } else {
+                handler.removeCallbacks(this);
+                return;
+            }
         }
         dispatcher.add(nextMockedLocations);
         mockedLocations.addAll(nextMockedLocations);


### PR DESCRIPTION
This pull request fixes a small bug of the `RouteReplayLocationEngine`. If there were any waypoints, the route replay was stopping at first one.