### PR TITLE
Fix Jitpack Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 Maplibre welcomes participation and contributions from everyone.
 
+### v1.2.1 - November 26, 2022
+
+- Fixed Jitpack Build
+
 ### v1.2.0 - November 21, 2022 
+
+(Please use v1.2.1, as the Release Build failed at Jitpack)
 
 - Fixed unit tests and updated some build dependencies. 
 - Added Flags for pending intents which are required in Android 31+

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -98,7 +98,6 @@ ext {
             gmsLocation            : "com.google.android.gms:play-services-location:${version.gmsLocation}",
 
             errorprone             : "com.google.errorprone:error_prone_core:${version.errorprone}"
-
     ]
 
     pluginDependencies = [

--- a/gradle/mvn-push-android.gradle
+++ b/gradle/mvn-push-android.gradle
@@ -108,6 +108,7 @@ afterEvaluate { project ->
   }
 
   task androidJavadocs(type: Javadoc) {
+    failOnError false
     source = android.sourceSets.main.java.srcDirs
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
   }

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
It appears that with the update of error prone, the jitpack build was broken and the release 1.2.0 could not be released. This PR fixes the build.