### PR TITLE
Update Dependencies including Maplibre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 Maplibre welcomes participation and contributions from everyone.
 
-### v1.2.1 - November 26, 2022
+### v1.3.0 - unreleased
 
+- Update Maplibre to 9.5.2
+- Updated dependencies of used libs and build tools
+- Removed AccessToken usage
 - Fixed Jitpack Build
 
 ### v1.2.0 - November 21, 2022 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,17 +44,17 @@ android {
 dependencies {
     // Flitsmeister Navigation SDK
     implementation project(':libandroid-navigation')
-    implementation(dependenciesList.mapLibre){
+    implementation(dependenciesList.mapLibre) {
         exclude group: 'com.mapbox.mapboxsdk', module: 'mapbox-sdk-geojson'
         exclude group: 'com.mapbox.mapboxsdk', module: 'mapbox-sdk-turf'
     }
 
     // Support libraries
-    implementation dependenciesList.appcompat
-    implementation dependenciesList.supportDesign
-    implementation dependenciesList.supportRecyclerView
-    implementation dependenciesList.supportConstraintLayout
-    implementation dependenciesList.supportCardView
+    implementation dependenciesList.androidxAppcompat
+    implementation dependenciesList.materialDesign
+    implementation dependenciesList.androidxRecyclerView
+    implementation dependenciesList.androidxConstraintLayout
+    implementation dependenciesList.androidxCardView
     implementation dependenciesList.lifecycleExtensions
 
     implementation dependenciesList.gmsLocation
@@ -63,10 +63,10 @@ dependencies {
     implementation dependenciesList.timber
 
     // Butter Knife
-    implementation 'com.jakewharton:butterknife:10.0.0'
-    annotationProcessor 'com.jakewharton:butterknife-compiler:10.0.0'
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation dependenciesList.butterknife
+    annotationProcessor dependenciesList.butterknifeProcessor
+    implementation dependenciesList.androidxAppcompat
+    implementation dependenciesList.androidxConstraintLayout
 
     // Leak Canary
     debugImplementation dependenciesList.leakCanaryDebug
@@ -82,10 +82,11 @@ dependencies {
     androidTestImplementation(dependenciesList.testEspressoCore, {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-  implementation dependenciesList.androidxCore
-  implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.0.0"
-  implementation dependenciesList.kotlinstdlib
+    implementation dependenciesList.androidxCore
+    implementation dependenciesList.kotlinstdlib
 
+    // Separate dependencies of the app that don't need to be in the public dependencies API
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1"
     implementation 'androidx.multidex:multidex:2.0.1'
 }
 
@@ -93,5 +94,5 @@ apply from: "${rootDir}/gradle/developer-config.gradle"
 apply from: "${rootDir}/gradle/checkstyle.gradle"
 apply from: "${rootDir}/gradle/dependency-updates.gradle"
 repositories {
-  mavenCentral()
+    mavenCentral()
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion androidVersions.compileSdkVersion
@@ -34,6 +33,10 @@ android {
         maxProcessCount 8
         javaMaxHeapSize "2g"
         preDexLibraries true
+    }
+
+    buildFeatures {
+        viewBinding = true
     }
 
     lintOptions {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     })
   implementation "androidx.core:core-ktx:1.7.0"
   implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.0.0"
-  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+  implementation dependenciesList.kotlinstdlib
 
     implementation 'androidx.multidex:multidex:2.0.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     }
 
     // Support libraries
-    implementation dependenciesList.supportAppcompatV7
+    implementation dependenciesList.appcompat
     implementation dependenciesList.supportDesign
     implementation dependenciesList.supportRecyclerView
     implementation dependenciesList.supportConstraintLayout
@@ -82,7 +82,7 @@ dependencies {
     androidTestImplementation(dependenciesList.testEspressoCore, {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-  implementation "androidx.core:core-ktx:1.7.0"
+  implementation dependenciesList.androidxCore
   implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.0.0"
   implementation dependenciesList.kotlinstdlib
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,7 +20,9 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".MainActivity" />
         </activity>
-        <activity android:name=".MainActivity">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/CustomNavigationNotification.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/CustomNavigationNotification.java
@@ -73,7 +73,7 @@ public class CustomNavigationNotification implements NavigationNotification {
 
     private PendingIntent createPendingStopIntent(Context context) {
         Intent stopNavigationIntent = new Intent(STOP_NAVIGATION_ACTION);
-        return PendingIntent.getBroadcast(context, 0, stopNavigationIntent, 0);
+        return PendingIntent.getBroadcast(context, 0, stopNavigationIntent, PendingIntent.FLAG_IMMUTABLE);
     }
 
     @RequiresApi(Build.VERSION_CODES.O)

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/MainActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/MainActivity.java
@@ -57,6 +57,7 @@ public class MainActivity extends AppCompatActivity implements PermissionsListen
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
                                            @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         permissionsManager.onRequestPermissionsResult(requestCode, permissions, grantResults);
     }
 

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/MockNavigationActivity.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/MockNavigationActivity.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.res.AssetManager
 import android.location.Location
 import android.os.Build
 import android.os.Bundle
@@ -68,7 +69,7 @@ class MockNavigationActivity : AppCompatActivity(), OnMapReadyCallback,
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityMockNavigationBinding.inflate(layoutInflater)
-        setContentView(R.layout.activity_mock_navigation)
+        setContentView(binding.root)
         binding.mapView.apply {
             onCreate(savedInstanceState)
             getMapAsync(this@MockNavigationActivity)
@@ -148,7 +149,6 @@ class MockNavigationActivity : AppCompatActivity(), OnMapReadyCallback,
         Snackbar.make(findViewById(R.id.container), "Tap map to place waypoint", Snackbar.LENGTH_LONG).show()
 
         newOrigin()
-
     }
 
     @SuppressWarnings("MissingPermission")

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/MockNavigationActivity.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/MockNavigationActivity.kt
@@ -30,6 +30,7 @@ import com.mapbox.mapboxsdk.location.modes.RenderMode
 import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback
 import com.mapbox.mapboxsdk.maps.Style
+import com.mapbox.services.android.navigation.testapp.databinding.ActivityMockNavigationBinding
 import com.mapbox.services.android.navigation.v5.instruction.Instruction
 import com.mapbox.services.android.navigation.v5.location.replay.ReplayRouteLocationEngine
 import com.mapbox.services.android.navigation.v5.milestone.*
@@ -39,7 +40,6 @@ import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeLis
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress
 import com.mapbox.turf.TurfConstants
 import com.mapbox.turf.TurfMeasurement
-import kotlinx.android.synthetic.main.activity_mock_navigation.*
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -62,11 +62,14 @@ class MockNavigationActivity : AppCompatActivity(), OnMapReadyCallback,
     private var waypoint: Point? = null
     private var locationComponent: LocationComponent? = null
 
+    private lateinit var binding : ActivityMockNavigationBinding
+
     @SuppressLint("MissingPermission")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        binding = ActivityMockNavigationBinding.inflate(layoutInflater)
         setContentView(R.layout.activity_mock_navigation)
-        mapView.apply {
+        binding.mapView.apply {
             onCreate(savedInstanceState)
             getMapAsync(this@MockNavigationActivity)
         }
@@ -94,9 +97,9 @@ class MockNavigationActivity : AppCompatActivity(), OnMapReadyCallback,
                     ).build())
             customNotification.register(MyBroadcastReceiver(navigation), context)
 
-        startRouteButton.setOnClickListener {
+        binding.startRouteButton.setOnClickListener {
             route?.let { route ->
-                startRouteButton.visibility = View.INVISIBLE
+                binding.startRouteButton.visibility = View.INVISIBLE
 
                 // Attach all of our navigation listeners.
                 navigation.apply {
@@ -116,11 +119,11 @@ class MockNavigationActivity : AppCompatActivity(), OnMapReadyCallback,
             }
         }
 
-        newLocationFab.setOnClickListener {
+        binding.newLocationFab.setOnClickListener {
             newOrigin()
         }
 
-        clearPoints.setOnClickListener {
+        binding.clearPoints.setOnClickListener {
             if (::mapboxMap.isInitialized)
                 mapboxMap.markers.forEach {
                     mapboxMap.removeMarker(it)
@@ -139,7 +142,7 @@ class MockNavigationActivity : AppCompatActivity(), OnMapReadyCallback,
             enableLocationComponent(style)
         }
 
-        navigationMapRoute = NavigationMapRoute(navigation, mapView, mapboxMap)
+        navigationMapRoute = NavigationMapRoute(navigation, binding.mapView, mapboxMap)
 
         mapboxMap.addOnMapClickListener(this)
         Snackbar.make(findViewById(R.id.container), "Tap map to place waypoint", Snackbar.LENGTH_LONG).show()
@@ -183,9 +186,9 @@ class MockNavigationActivity : AppCompatActivity(), OnMapReadyCallback,
 
         if (addMarker)
             mapboxMap.addMarker(MarkerOptions().position(point))
-        clearPoints.visibility = View.VISIBLE
+        binding.clearPoints.visibility = View.VISIBLE
 
-        startRouteButton.visibility = View.VISIBLE
+        binding.startRouteButton.visibility = View.VISIBLE
         calculateRoute()
         return true
     }
@@ -205,7 +208,7 @@ class MockNavigationActivity : AppCompatActivity(), OnMapReadyCallback,
 
         val origin = Point.fromLngLat(userLocation.longitude, userLocation.latitude)
         if (TurfMeasurement.distance(origin, destination, TurfConstants.UNIT_METERS) < 50) {
-            startRouteButton.visibility = View.GONE
+            binding.startRouteButton.visibility = View.GONE
             return
         }
 
@@ -261,27 +264,27 @@ class MockNavigationActivity : AppCompatActivity(), OnMapReadyCallback,
 
     override fun onResume() {
         super.onResume()
-        mapView.onResume()
+        binding.mapView.onResume()
     }
 
     override fun onPause() {
         super.onPause()
-        mapView.onPause()
+        binding.mapView.onPause()
     }
 
     override fun onStart() {
         super.onStart()
-        mapView.onStart()
+        binding.mapView.onStart()
     }
 
     override fun onStop() {
         super.onStop()
-        mapView.onStop()
+        binding.mapView.onStop()
     }
 
     override fun onLowMemory() {
         super.onLowMemory()
-        mapView.onLowMemory()
+        binding.mapView.onLowMemory()
     }
 
     override fun onDestroy() {
@@ -290,12 +293,12 @@ class MockNavigationActivity : AppCompatActivity(), OnMapReadyCallback,
         if (::mapboxMap.isInitialized) {
             mapboxMap.removeOnMapClickListener(this)
         }
-        mapView.onDestroy()
+        binding.mapView.onDestroy()
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        mapView.onSaveInstanceState(outState)
+        binding.mapView.onSaveInstanceState(outState)
     }
 
 

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/MockNavigationActivity.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/MockNavigationActivity.kt
@@ -80,8 +80,7 @@ class MockNavigationActivity : AppCompatActivity(), OnMapReadyCallback,
                 .navigationNotification(customNotification)
                 .build()
 
-        Mapbox.getAccessToken()?.let {
-            navigation = MapboxNavigation(this, it, options)
+            navigation = MapboxNavigation(this, options)
 
             navigation.addMilestone(RouteMilestone.Builder()
                     .setIdentifier(BEGIN_ROUTE_MILESTONE)
@@ -94,7 +93,6 @@ class MockNavigationActivity : AppCompatActivity(), OnMapReadyCallback,
                             )
                     ).build())
             customNotification.register(MyBroadcastReceiver(navigation), context)
-        }
 
         startRouteButton.setOnClickListener {
             route?.let { route ->
@@ -194,7 +192,7 @@ class MockNavigationActivity : AppCompatActivity(), OnMapReadyCallback,
 
     private fun calculateRoute() {
         val userLocation = locationEngine.lastLocation
-        val accesstoken = Mapbox.getAccessToken()
+        val accesstoken = "pk.0"
         val destination = destination
         if (userLocation == null) {
             Timber.d("calculateRoute: User location is null, therefore, origin can't be set.")

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/NavigationApplication.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/NavigationApplication.java
@@ -6,7 +6,6 @@ import android.text.TextUtils;
 import android.util.Log;
 
 import com.mapbox.mapboxsdk.Mapbox;
-import com.squareup.leakcanary.LeakCanary;
 
 import timber.log.Timber;
 
@@ -18,12 +17,6 @@ public class NavigationApplication extends Application {
   @Override
   public void onCreate() {
     super.onCreate();
-
-    // Leak canary
-    if (LeakCanary.isInAnalyzerProcess(this)) {
-      return;
-    }
-    LeakCanary.install(this);
 
     if (BuildConfig.DEBUG) {
       Timber.plant(new Timber.DebugTree());

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/NavigationApplication.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/NavigationApplication.java
@@ -35,7 +35,7 @@ public class NavigationApplication extends Application {
       Log.w(LOG_TAG, "Warning: access token isn't set.");
     }
 
-    Mapbox.getInstance(getApplicationContext(), mapboxAccessToken);
+    Mapbox.getInstance(getApplicationContext());
   }
 
 }

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/NavigationApplication.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/NavigationApplication.java
@@ -1,9 +1,6 @@
 package com.mapbox.services.android.navigation.testapp;
 
 import android.app.Application;
-import android.app.NotificationChannel;
-import android.text.TextUtils;
-import android.util.Log;
 
 import com.mapbox.mapboxsdk.Mapbox;
 
@@ -20,12 +17,6 @@ public class NavigationApplication extends Application {
 
     if (BuildConfig.DEBUG) {
       Timber.plant(new Timber.DebugTree());
-    }
-
-    // Set access token
-    String mapboxAccessToken = Utils.getMapboxAccessToken(getApplicationContext());
-    if (TextUtils.isEmpty(mapboxAccessToken) || mapboxAccessToken.equals(DEFAULT_MAPBOX_ACCESS_TOKEN)) {
-      Log.w(LOG_TAG, "Warning: access token isn't set.");
     }
 
     Mapbox.getInstance(getApplicationContext());

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/Utils.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/Utils.java
@@ -21,33 +21,6 @@ import timber.log.Timber;
 public class Utils {
 
   /**
-   * <p>
-   * Returns the Mapbox access token set in the app resources.
-   * </p>
-   * It will first search for a token in the Mapbox object. If not found it
-   * will then attempt to load the access token from the
-   * {@code res/values/dev.xml} development file.
-   *
-   * @param context The {@link Context} of the {@link android.app.Activity} or {@link android.app.Fragment}.
-   * @return The Mapbox access token or null if not found.
-   */
-  public static String getMapboxAccessToken(@NonNull Context context) {
-    try {
-      // Read out AndroidManifest
-      String token = "pk.0";
-      if (token == null || token.isEmpty()) {
-        throw new IllegalArgumentException();
-      }
-      return token;
-    } catch (Exception exception) {
-      // Use fallback on string resource, used for development
-      int tokenResId = context.getResources()
-        .getIdentifier("mapbox_access_token", "string", context.getPackageName());
-      return tokenResId != 0 ? context.getString(tokenResId) : null;
-    }
-  }
-
-  /**
    * Demonstrates converting any Drawable to an Icon, for use as a marker icon.
    */
   public static Icon drawableToIcon(@NonNull Context context, @DrawableRes int id) {

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/Utils.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/Utils.java
@@ -34,7 +34,7 @@ public class Utils {
   public static String getMapboxAccessToken(@NonNull Context context) {
     try {
       // Read out AndroidManifest
-      String token = Mapbox.getAccessToken();
+      String token = "pk.0";
       if (token == null || token.isEmpty()) {
         throw new IllegalArgumentException();
       }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.github.kt3k.coveralls'
 
 buildscript {
-    ext.kotlin_version = '1.7.20'
     apply from: "${rootDir}/gradle/dependencies.gradle"
 
   repositories {
@@ -11,12 +10,11 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:4.2.2'
     classpath pluginDependencies.gradle
     classpath pluginDependencies.coveralls
     classpath pluginDependencies.errorprone
     classpath pluginDependencies.dependencyUpdates
-      classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    classpath pluginDependencies.kotlinGradle
   }
 }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -4,11 +4,12 @@ ext {
             minSdkVersion    : 15,
             targetSdkVersion : 30,
             compileSdkVersion: 31,
-            buildToolsVersion: '30.0.3'
+            buildToolsVersion: '30.0.3',
+            kotlinVersion      : '1.7.20'
     ]
 
     version = [
-            mapLibreVersion     : '9.4.0',
+            mapLibreVersion     : '9.5.2',
             mapLibreService     : '5.9.0',
             mapLibreTurf        : '5.9.0',
             mapLibreAnnotations : '1.0.0',
@@ -30,7 +31,7 @@ ext {
             robolectric         : '4.5',
             lifecycle           : '1.1.1',
             picasso             : '2.71828',
-            gmsLocation         : '16.0.0'
+            gmsLocation         : '16.0.0',
     ]
 
     pluginVersion = [
@@ -39,9 +40,10 @@ ext {
             errorprone       : '2.0.2',
             coveralls        : '2.8.1',
             spotbugs         : '1.3',
-            gradle           : '3.2.0',
+            gradle           : '4.2.2',
+            kotlinGradle    : '1.7.20',
             dependencyGraph  : '0.3.0',
-            dependencyUpdates: '0.20.0'
+            dependencyUpdates: '0.44.0'
     ]
 
     dependenciesList = [
@@ -68,6 +70,7 @@ ext {
             supportRecyclerView    : 'androidx.recyclerview:recyclerview:1.0.0',
             supportCardView        : 'androidx.cardview:cardview:1.0.0',
             supportConstraintLayout: 'androidx.constraintlayout:constraintlayout:1.1.3',
+            kotlinstdlib           : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${androidVersions.kotlinVersion}",
 
             // architecture
             lifecycleExtensions    : 'androidx.lifecycle:lifecycle-extensions:2.0.0',
@@ -107,6 +110,7 @@ ext {
             coveralls        : "org.kt3k.gradle.plugin:coveralls-gradle-plugin:${pluginVersion.coveralls}",
             errorprone       : "net.ltgt.gradle:gradle-errorprone-plugin:${pluginVersion.errorprone}",
             dependencyGraph  : "com.vanniktech:gradle-dependency-graph-generator-plugin:${pluginVersion.dependencyGraph}",
-            dependencyUpdates: "com.github.ben-manes:gradle-versions-plugin:${pluginVersion.dependencyUpdates}"
+            dependencyUpdates: "com.github.ben-manes:gradle-versions-plugin:${pluginVersion.dependencyUpdates}",
+            kotlinGradle     : "org.jetbrains.kotlin:kotlin-gradle-plugin:${androidVersions.kotlinVersion}"
     ]
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,38 +1,44 @@
 ext {
 
     androidVersions = [
-            minSdkVersion       : 15,
-            targetSdkVersion    : 33,
-            compileSdkVersion   : 33,
-            buildToolsVersion   : '33.0.1',
-            kotlinVersion       : '1.7.20'
+            minSdkVersion    : 15,
+            targetSdkVersion : 33,
+            compileSdkVersion: 33,
+            buildToolsVersion: '33.0.1',
+            kotlinVersion    : '1.7.20'
     ]
 
     version = [
-            mapLibreVersion     : '9.5.2',
-            mapLibreService     : '5.9.0',
-            mapLibreTurf        : '5.9.0',
-            mapLibreAnnotations : '1.0.0',
-            autoValue           : '1.5.4',
-            autoValueParcel     : '0.2.5',
-            junit               : '4.12',
-            androidxCoreVersion : '1.9.0',
-            supportLibVersion   : '28.0.0',
-            constraintLayout    : '1.1.2',
-            mockito             : '2.21.0',
-            hamcrest            : '2.0.0.0',
-            errorprone          : '2.16',
-            butterknife         : '8.8.1',
-            leakCanaryVersion   : '2.10',
-            timber              : '4.7.1',
-            testRunnerVersion   : '1.0.1',
-            espressoVersion     : '3.0.2',
-            spoonRunner         : '1.6.2',
-            commonsIO           : '2.6',
-            robolectric         : '4.5',
-            lifecycle           : '1.1.1',
-            picasso             : '2.71828',
-            gmsLocation         : '16.0.0',
+            mapLibreVersion        : '9.5.2',
+            mapLibreService        : '5.9.0',
+            mapLibreTurf           : '5.9.0',
+            mapLibreAnnotations    : '1.0.0',
+            autoValue              : '1.10.1',
+            autoValueParcel        : '0.2.5',
+            junit                  : '4.13.2',
+            androidxCoreVersion    : '1.9.0',
+            appcompatVersion       : '1.5.1',
+            cardViewVersion        : '1.0.0',
+            supportLibVersion      : '28.0.0',
+            constraintLayoutVersion: '2.1.4',
+            materialVersion        : '1.7.0',
+            recyclerViewVersion    : '1.2.1',
+            mockito                : '4.9.0',
+            hamcrest               : '2.0.0.0',
+            errorprone             : '2.16',
+            butterknife            : '10.2.3',
+            leakCanaryVersion      : '2.10',
+            timber                 : '5.0.1',
+            testRunnerVersion      : '1.0.1',
+            espressoVersion        : '3.5.0',
+            spoonRunner            : '1.6.2',
+            commonsIO              : '2.6',
+            robolectric            : '4.9',
+            lifecycle              : '1.1.1',
+            lifecycleVersion       : '2.2.0',
+            picasso                : '2.71828',
+            gmsLocation            : '16.0.0',
+            testRulesVersion       : '1.5.0'
     ]
 
     pluginVersion = [
@@ -42,77 +48,77 @@ ext {
             coveralls        : '2.8.1',
             spotbugs         : '1.3',
             gradle           : '7.3.1',
-            kotlinGradle    : '1.7.20',
+            kotlinGradle     : '1.7.20',
             dependencyGraph  : '0.3.0',
             dependencyUpdates: '0.44.0'
     ]
 
     dependenciesList = [
             // maplibre
-            mapLibre               : "org.maplibre.gl:android-sdk:${version.mapLibreVersion}",
-            mapLibreServices       : "org.maplibre.gl:android-sdk-services:${version.mapLibreService}",
-            mapLibreTurf           : "org.maplibre.gl:android-sdk-turf:${version.mapLibreTurf}",
-            mapLibreAnnotations    : "org.maplibre.gl:android-plugin-annotation-v9:${version.mapLibreAnnotations}",
+            mapLibre                : "org.maplibre.gl:android-sdk:${version.mapLibreVersion}",
+            mapLibreServices        : "org.maplibre.gl:android-sdk-services:${version.mapLibreService}",
+            mapLibreTurf            : "org.maplibre.gl:android-sdk-turf:${version.mapLibreTurf}",
+            mapLibreAnnotations     : "org.maplibre.gl:android-plugin-annotation-v9:${version.mapLibreAnnotations}",
 
             // AutoValue
-            autoValue              : "com.google.auto.value:auto-value:${version.autoValue}",
-            autoValuesParcel       : "com.ryanharter.auto.value:auto-value-parcel:${version.autoValueParcel}",
-            autoValuesParcelAdapter: "com.ryanharter.auto.value:auto-value-parcel-adapter:${version.autoValueParcel}",
+            autoValue               : "com.google.auto.value:auto-value:${version.autoValue}",
+            autoValueAnnotations    : "com.google.auto.value:auto-value-annotations:${version.autoValue}",
+            autoValuesParcel        : "com.ryanharter.auto.value:auto-value-parcel:${version.autoValueParcel}",
+            autoValuesParcelAdapter : "com.ryanharter.auto.value:auto-value-parcel-adapter:${version.autoValueParcel}",
 
             // butterknife
-            butterKnife            : "com.jakewharton:butterknife:${version.butterknife}",
-            butterKnifeProcessor   : "com.jakewharton:butterknife-compiler:${version.butterknife}",
+            butterknife             : "com.jakewharton:butterknife:${version.butterknife}",
+            butterknifeProcessor    : "com.jakewharton:butterknife-compiler:${version.butterknife}",
 
             // support
-            supportAnnotation      : "com.android.support:support-annotations:${version.supportLibVersion}",
-            appcompat              : 'androidx.appcompat:appcompat:1.0.0',
-            androidxCore           : "androidx.core:core-ktx:${version.androidxCoreVersion}",
-            supportV4              : "com.android.support:support-v4:${version.supportLibVersion}",
-            supportDesign          : 'com.google.android.material:material:1.0.0',
-            supportRecyclerView    : 'androidx.recyclerview:recyclerview:1.0.0',
-            supportCardView        : 'androidx.cardview:cardview:1.0.0',
-            supportConstraintLayout: 'androidx.constraintlayout:constraintlayout:1.1.3',
-            kotlinstdlib           : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${androidVersions.kotlinVersion}",
+            androidxAppcompat       : "androidx.appcompat:appcompat:${version.appcompatVersion}",
+            androidxCore            : "androidx.core:core-ktx:${version.androidxCoreVersion}",
+            supportAnnotation       : "com.android.support:support-annotations:${version.supportLibVersion}",
+            supportV4               : "com.android.support:support-v4:${version.supportLibVersion}",
+            materialDesign          : "com.google.android.material:material:${version.materialVersion}",
+            androidxRecyclerView    : "androidx.recyclerview:recyclerview:${version.recyclerViewVersion}",
+            androidxCardView        : "androidx.cardview:cardview:${version.cardViewVersion}",
+            androidxConstraintLayout: "androidx.constraintlayout:constraintlayout:${version.constraintLayoutVersion}",
+            kotlinstdlib            : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${androidVersions.kotlinVersion}",
 
             // architecture
-            lifecycleExtensions    : 'androidx.lifecycle:lifecycle-extensions:2.0.0',
-            lifecycleCompiler      : "android.arch.lifecycle:compiler:${version.lifecycle}",
+            lifecycleExtensions     : "androidx.lifecycle:lifecycle-extensions:${version.lifecycleVersion}",
+            lifecycleCompiler       : "android.arch.lifecycle:compiler:${version.lifecycle}",
 
             // square crew
-            timber                 : "com.jakewharton.timber:timber:${version.timber}",
-            picasso                : "com.squareup.picasso:picasso:${version.picasso}",
-            leakCanaryDebug        : "com.squareup.leakcanary:leakcanary-android:${version.leakCanaryVersion}",
-            leakCanaryRelease      : "com.squareup.leakcanary:leakcanary-android-no-op:${version.leakCanaryVersion}",
-            leakCanaryTest         : "com.squareup.leakcanary:leakcanary-android-no-op:${version.leakCanaryVersion}",
+            timber                  : "com.jakewharton.timber:timber:${version.timber}",
+            picasso                 : "com.squareup.picasso:picasso:${version.picasso}",
+            leakCanaryDebug         : "com.squareup.leakcanary:leakcanary-android:${version.leakCanaryVersion}",
+            leakCanaryRelease       : "com.squareup.leakcanary:leakcanary-android-no-op:${version.leakCanaryVersion}",
+            leakCanaryTest          : "com.squareup.leakcanary:leakcanary-android-no-op:${version.leakCanaryVersion}",
 
             // instrumentation test
-            testSpoonRunner        : "com.squareup.spoon:spoon-client:${version.spoonRunner}",
-            testRunner             : "com.android.support.test:runner:${version.testRunnerVersion}",
-            testRules              : 'androidx.test:rules:1.1.0',
-            testEspressoCore       : 'androidx.test.espresso:espresso-core:3.1.0',
-            testEspressoIntents    : "com.android.support.test.espresso:espresso-intents:${version.espressoVersion}",
+            testSpoonRunner         : "com.squareup.spoon:spoon-client:${version.spoonRunner}",
+            testRunner              : "com.android.support.test:runner:${version.testRunnerVersion}",
+            testRules               : "androidx.test:rules:${version.testRulesVersion}",
+            testEspressoCore        : "androidx.test.espresso:espresso-core:${version.espressoVersion}",
+            testEspressoIntents     : "com.android.support.test.espresso:espresso-intents:${version.espressoVersion}",
 
             // unit test
-            junit                  : "junit:junit:${version.junit}",
-            mockito                : "org.mockito:mockito-core:${version.mockito}",
-            hamcrest               : "org.hamcrest:hamcrest-junit:${version.hamcrest}",
-            commonsIO              : "commons-io:commons-io:${version.commonsIO}",
-            robolectric            : "org.robolectric:robolectric:${version.robolectric}",
+            junit                   : "junit:junit:${version.junit}",
+            mockito                 : "org.mockito:mockito-core:${version.mockito}",
+            hamcrest                : "org.hamcrest:hamcrest-junit:${version.hamcrest}",
+            commonsIO               : "commons-io:commons-io:${version.commonsIO}",
+            robolectric             : "org.robolectric:robolectric:${version.robolectric}",
 
             // play services
-            gmsLocation            : "com.google.android.gms:play-services-location:${version.gmsLocation}",
-
-            errorprone             : "com.google.errorprone:error_prone_core:${version.errorprone}"
+            gmsLocation             : "com.google.android.gms:play-services-location:${version.gmsLocation}",
+            errorprone              : "com.google.errorprone:error_prone_core:${version.errorprone}"
     ]
 
     pluginDependencies = [
-            gradle           : "com.android.tools.build:gradle:${pluginVersion.gradle}",
-            checkstyle       : "com.puppycrawl.tools:checkstyle:${pluginVersion.checkstyle}",
-            spotbugs         : "gradle.plugin.com.github.spotbugs:gradlePlugin:${pluginVersion.spotbugs}",
-            coveralls        : "org.kt3k.gradle.plugin:coveralls-gradle-plugin:${pluginVersion.coveralls}",
-            errorprone       : "net.ltgt.gradle:gradle-errorprone-plugin:${pluginVersion.errorprone}",
-            dependencyGraph  : "com.vanniktech:gradle-dependency-graph-generator-plugin:${pluginVersion.dependencyGraph}",
-            dependencyUpdates: "com.github.ben-manes:gradle-versions-plugin:${pluginVersion.dependencyUpdates}",
-            kotlinGradle     : "org.jetbrains.kotlin:kotlin-gradle-plugin:${androidVersions.kotlinVersion}"
+            gradle              : "com.android.tools.build:gradle:${pluginVersion.gradle}",
+            checkstyle          : "com.puppycrawl.tools:checkstyle:${pluginVersion.checkstyle}",
+            spotbugs            : "gradle.plugin.com.github.spotbugs:gradlePlugin:${pluginVersion.spotbugs}",
+            coveralls           : "org.kt3k.gradle.plugin:coveralls-gradle-plugin:${pluginVersion.coveralls}",
+            errorprone          : "net.ltgt.gradle:gradle-errorprone-plugin:${pluginVersion.errorprone}",
+            dependencyGraph     : "com.vanniktech:gradle-dependency-graph-generator-plugin:${pluginVersion.dependencyGraph}",
+            dependencyUpdates   : "com.github.ben-manes:gradle-versions-plugin:${pluginVersion.dependencyUpdates}",
+            kotlinGradle        : "org.jetbrains.kotlin:kotlin-gradle-plugin:${androidVersions.kotlinVersion}"
     ]
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,11 +1,11 @@
 ext {
 
     androidVersions = [
-            minSdkVersion    : 15,
-            targetSdkVersion : 30,
-            compileSdkVersion: 31,
-            buildToolsVersion: '30.0.3',
-            kotlinVersion      : '1.7.20'
+            minSdkVersion       : 15,
+            targetSdkVersion    : 33,
+            compileSdkVersion   : 33,
+            buildToolsVersion   : '33.0.1',
+            kotlinVersion       : '1.7.20'
     ]
 
     version = [
@@ -16,13 +16,14 @@ ext {
             autoValue           : '1.5.4',
             autoValueParcel     : '0.2.5',
             junit               : '4.12',
+            androidxCoreVersion : '1.9.0',
             supportLibVersion   : '28.0.0',
             constraintLayout    : '1.1.2',
             mockito             : '2.21.0',
             hamcrest            : '2.0.0.0',
             errorprone          : '2.16',
             butterknife         : '8.8.1',
-            leakCanaryVersion   : '1.6.1',
+            leakCanaryVersion   : '2.10',
             timber              : '4.7.1',
             testRunnerVersion   : '1.0.1',
             espressoVersion     : '3.0.2',
@@ -40,7 +41,7 @@ ext {
             errorprone       : '2.0.2',
             coveralls        : '2.8.1',
             spotbugs         : '1.3',
-            gradle           : '4.2.2',
+            gradle           : '7.3.1',
             kotlinGradle    : '1.7.20',
             dependencyGraph  : '0.3.0',
             dependencyUpdates: '0.44.0'
@@ -64,7 +65,8 @@ ext {
 
             // support
             supportAnnotation      : "com.android.support:support-annotations:${version.supportLibVersion}",
-            supportAppcompatV7     : 'androidx.appcompat:appcompat:1.0.0',
+            appcompat              : 'androidx.appcompat:appcompat:1.0.0',
+            androidxCore           : "androidx.core:core-ktx:${version.androidxCoreVersion}",
             supportV4              : "com.android.support:support-v4:${version.supportLibVersion}",
             supportDesign          : 'com.google.android.material:material:1.0.0',
             supportRecyclerView    : 'androidx.recyclerview:recyclerview:1.0.0',

--- a/gradle/dependency-updates.gradle
+++ b/gradle/dependency-updates.gradle
@@ -1,13 +1,15 @@
+import com.github.benmanes.gradle.versions.VersionsPlugin
+
 buildscript {
     repositories {
-        jcenter()
+        gradlePluginPortal()
     }
     dependencies {
-        classpath pluginDependencies.dependencyUpdates
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.44.0'
     }
 }
 
-apply plugin: "com.github.ben-manes.versions"
+apply plugin: VersionsPlugin
 
 // disallow release candidates as upgradable versions
 dependencyUpdates.resolutionStrategy {

--- a/gradle/dependency-updates.gradle
+++ b/gradle/dependency-updates.gradle
@@ -5,7 +5,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.44.0'
+        classpath pluginDependencies.dependencyUpdates
     }
 }
 

--- a/gradle/dependency-updates.gradle
+++ b/gradle/dependency-updates.gradle
@@ -5,7 +5,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath pluginDependencies.dependencyUpdates
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.44.0'
     }
 }
 

--- a/gradle/mvn-push-android.gradle
+++ b/gradle/mvn-push-android.gradle
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-apply plugin: 'maven'
+plugins {
+  id 'maven-publish'
+}
 apply plugin: 'signing'
 
 def isReleaseBuild() {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/libandroid-navigation/build.gradle
+++ b/libandroid-navigation/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     compileOnly dependenciesList.gmsLocation
 
     // Support
-    implementation dependenciesList.supportAppcompatV7
+    implementation dependenciesList.appcompat
 
     // Logging
     implementation dependenciesList.timber
@@ -66,16 +66,14 @@ dependencies {
     testImplementation dependenciesList.hamcrest
     testImplementation dependenciesList.commonsIO
     testImplementation dependenciesList.robolectric
-    implementation "androidx.core:core-ktx:1.7.0"
+    implementation dependenciesList.androidxCore
     implementation dependenciesList.kotlinstdlib
 }
 
 apply from: 'javadoc.gradle'
-apply from: "${rootDir}/gradle/mvn-push-android.gradle"
 apply from: "${rootDir}/gradle/checkstyle.gradle"
 apply from: "${rootDir}/gradle/dependencies-graph.gradle"
 apply from: "${rootDir}/gradle/dependency-updates.gradle"
 repositories {
     mavenCentral()
-    jcenter()
 }

--- a/libandroid-navigation/build.gradle
+++ b/libandroid-navigation/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion androidVersions.compileSdkVersion

--- a/libandroid-navigation/build.gradle
+++ b/libandroid-navigation/build.gradle
@@ -51,14 +51,14 @@ dependencies {
     compileOnly dependenciesList.gmsLocation
 
     // Support
-    implementation dependenciesList.appcompat
+    implementation dependenciesList.androidxAppcompat
 
     // Logging
     implementation dependenciesList.timber
 
     // AutoValues
     annotationProcessor dependenciesList.autoValue
-    compileOnly dependenciesList.autoValue
+    compileOnly dependenciesList.autoValueAnnotations
 
     // Unit testing
     testImplementation dependenciesList.junit

--- a/libandroid-navigation/build.gradle
+++ b/libandroid-navigation/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     testImplementation dependenciesList.commonsIO
     testImplementation dependenciesList.robolectric
     implementation "androidx.core:core-ktx:1.7.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation dependenciesList.kotlinstdlib
 }
 
 apply from: 'javadoc.gradle'
@@ -77,4 +77,5 @@ apply from: "${rootDir}/gradle/dependencies-graph.gradle"
 apply from: "${rootDir}/gradle/dependency-updates.gradle"
 repositories {
     mavenCentral()
+    jcenter()
 }

--- a/libandroid-navigation/src/main/AndroidManifest.xml
+++ b/libandroid-navigation/src/main/AndroidManifest.xml
@@ -13,7 +13,6 @@
             android:exported="false"
             android:initOrder="100"
             tools:node="remove" />
-        <service android:name="com.mapbox.services.android.navigation.v5.navigation.NavigationService"/>
         <!-- Include the telemetry service to simplify set up (https://www.mapbox.com/telemetry) -->
         <service android:name="com.mapbox.services.android.telemetry.service.TelemetryService"/>
     </application>

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -56,7 +56,6 @@ public class MapboxNavigation implements ServiceConnection {
   private MapboxNavigationOptions options;
   private LocationEngine locationEngine = null;
   private Set<Milestone> milestones;
-  private final String accessToken;
   private Context applicationContext;
   private boolean isBound;
 
@@ -71,11 +70,10 @@ public class MapboxNavigation implements ServiceConnection {
    * </p>
    *
    * @param context     required in order to create and bind the navigation service
-   * @param accessToken a valid Mapbox access token
    * @since 0.5.0
    */
-  public MapboxNavigation(@NonNull Context context, @NonNull String accessToken) {
-    this(context, accessToken, MapboxNavigationOptions.builder().build());
+  public MapboxNavigation(@NonNull Context context) {
+    this(context, MapboxNavigationOptions.builder().build());
   }
 
   /**
@@ -92,14 +90,11 @@ public class MapboxNavigation implements ServiceConnection {
    *
    * @param context     required in order to create and bind the navigation service
    * @param options     a custom built {@code MapboxNavigationOptions} class
-   * @param accessToken a valid Mapbox access token
    * @see MapboxNavigationOptions
    * @since 0.5.0
    */
-  public MapboxNavigation(@NonNull Context context, @NonNull String accessToken,
-                          @NonNull MapboxNavigationOptions options) {
+  public MapboxNavigation(@NonNull Context context, @NonNull MapboxNavigationOptions options) {
     initializeContext(context);
-    this.accessToken = accessToken;
     this.options = options;
     initialize();
   }
@@ -111,26 +106,21 @@ public class MapboxNavigation implements ServiceConnection {
    * through the options class cannot be modified.
    *
    * @param context        required in order to create and bind the navigation service
-   * @param accessToken    a valid Mapbox access token
    * @param options        a custom built {@code MapboxNavigationOptions} class
    * @param locationEngine a LocationEngine to provide Location updates
    * @see MapboxNavigationOptions
    * @since 0.19.0
    */
-  public MapboxNavigation(@NonNull Context context, @NonNull String accessToken,
-                          @NonNull MapboxNavigationOptions options, @NonNull LocationEngine locationEngine) {
+  public MapboxNavigation(@NonNull Context context, @NonNull MapboxNavigationOptions options, @NonNull LocationEngine locationEngine) {
     initializeContext(context);
-    this.accessToken = accessToken;
     this.options = options;
     this.locationEngine = locationEngine;
     initialize();
   }
 
   // Package private (no modifier) for testing purposes
-  MapboxNavigation(@NonNull Context context, @NonNull String accessToken,
-                   LocationEngine locationEngine) {
+  MapboxNavigation(@NonNull Context context, LocationEngine locationEngine) {
     initializeContext(context);
-    this.accessToken = accessToken;
     this.options = MapboxNavigationOptions.builder().build();
     this.locationEngine = locationEngine;
     initialize();
@@ -693,10 +683,6 @@ public class MapboxNavigation implements ServiceConnection {
   @NonNull
   public FasterRoute getFasterRouteEngine() {
     return navigationEngineFactory.retrieveFasterRouteEngine();
-  }
-
-  String obtainAccessToken() {
-    return accessToken;
   }
 
   DirectionsRoute getRoute() {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
@@ -92,18 +92,16 @@ public class NavigationService extends Service {
 
     private void initialize(MapboxNavigation mapboxNavigation) {
         NavigationEventDispatcher dispatcher = mapboxNavigation.getEventDispatcher();
-        String accessToken = mapboxNavigation.obtainAccessToken();
-        initializeRouteFetcher(dispatcher, accessToken, mapboxNavigation.retrieveEngineProvider());
+        initializeRouteFetcher(dispatcher, mapboxNavigation.retrieveEngineProvider());
         initializeNotificationProvider(mapboxNavigation);
         initializeRouteProcessorThread(dispatcher, routeFetcher, notificationProvider);
         initializeLocationProvider(mapboxNavigation);
     }
 
-    private void initializeRouteFetcher(NavigationEventDispatcher dispatcher, String accessToken,
-                                        NavigationEngineFactory engineProvider) {
+    private void initializeRouteFetcher(NavigationEventDispatcher dispatcher, NavigationEngineFactory engineProvider) {
         FasterRoute fasterRouteEngine = engineProvider.retrieveFasterRouteEngine();
         NavigationFasterRouteListener listener = new NavigationFasterRouteListener(dispatcher, fasterRouteEngine);
-        routeFetcher = new RouteFetcher(getApplication(), accessToken);
+        routeFetcher = new RouteFetcher(getApplication());
         routeFetcher.addRouteListener(listener);
     }
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/RouteFetcher.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/RouteFetcher.java
@@ -154,7 +154,6 @@ public class RouteFetcher {
 
   private void executeRouteCall(NavigationRoute.Builder builder) {
     if (builder != null) {
-      builder.accessToken("pk.0");
       builder.build().getRoute(directionsResponseCallback);
     }
   }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/RouteFetcher.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/RouteFetcher.java
@@ -38,14 +38,12 @@ public class RouteFetcher {
   private static final int SECOND_POSITION = 1;
 
   private final List<RouteListener> routeListeners = new CopyOnWriteArrayList<>();
-  private final String accessToken;
   private final WeakReference<Context> contextWeakReference;
 
   private RouteProgress routeProgress;
   private RouteUtils routeUtils;
 
-  public RouteFetcher(Context context, String accessToken) {
-    this.accessToken = accessToken;
+  public RouteFetcher(Context context) {
     contextWeakReference = new WeakReference<>(context);
     routeUtils = new RouteUtils();
   }
@@ -156,7 +154,7 @@ public class RouteFetcher {
 
   private void executeRouteCall(NavigationRoute.Builder builder) {
     if (builder != null) {
-      builder.accessToken(accessToken);
+      builder.accessToken("pk.0");
       builder.build().getRoute(directionsResponseCallback);
     }
   }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/FasterRouteDetectorTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/FasterRouteDetectorTest.java
@@ -115,7 +115,7 @@ public class FasterRouteDetectorTest extends BaseTest {
       .build();
     Context context = mock(Context.class);
     when(context.getApplicationContext()).thenReturn(mock(Context.class));
-    return new MapboxNavigation(context, ACCESS_TOKEN, options, mock(LocationEngine.class));
+    return new MapboxNavigation(context, options, mock(LocationEngine.class));
   }
 
   private RouteProgress obtainDefaultRouteProgress() throws Exception {

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationTest.java
@@ -269,13 +269,13 @@ public class MapboxNavigationTest extends BaseTest {
   private MapboxNavigation buildMapboxNavigation() {
     Context context = mock(Context.class);
     when(context.getApplicationContext()).thenReturn(context);
-    return new MapboxNavigation(context, ACCESS_TOKEN,  mock(LocationEngine.class));
+    return new MapboxNavigation(context, mock(LocationEngine.class));
   }
 
   private MapboxNavigation buildMapboxNavigationWithOptions(MapboxNavigationOptions options) {
     Context context = mock(Context.class);
     when(context.getApplicationContext()).thenReturn(context);
-    return new MapboxNavigation(context, ACCESS_TOKEN, options, mock(LocationEngine.class));
+    return new MapboxNavigation(context, options, mock(LocationEngine.class));
   }
 
   private int searchForVoiceInstructionMilestone(MapboxNavigation navigation) {

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcherTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcherTest.java
@@ -65,7 +65,7 @@ public class NavigationEventDispatcherTest extends BaseTest {
         MockitoAnnotations.initMocks(this);
         Context context = mock(Context.class);
         when(context.getApplicationContext()).thenReturn(mock(Context.class));
-        navigation = new MapboxNavigation(context, ACCESS_TOKEN, mock(LocationEngine.class));
+        navigation = new MapboxNavigation(context, mock(LocationEngine.class));
         navigationEventDispatcher = navigation.getEventDispatcher();
 
         Gson gson = new GsonBuilder()

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationFasterRouteListenerTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationFasterRouteListenerTest.java
@@ -15,7 +15,7 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 public class NavigationFasterRouteListenerTest {
@@ -43,7 +43,7 @@ public class NavigationFasterRouteListenerTest {
 
     listener.onResponseReceived(response, routeProgress);
 
-    verifyZeroInteractions(eventDispatcher);
+    verifyNoInteractions (eventDispatcher);
   }
 
   @NonNull

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelperTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelperTest.java
@@ -97,7 +97,7 @@ public class NavigationHelperTest extends BaseTest {
                 .defaultMilestonesEnabled(false).build();
         Context context = mock(Context.class);
         when(context.getApplicationContext()).thenReturn(mock(Context.class));
-        MapboxNavigation mapboxNavigation = new MapboxNavigation(context, ACCESS_TOKEN, options, mock(LocationEngine.class));
+        MapboxNavigation mapboxNavigation = new MapboxNavigation(context, options, mock(LocationEngine.class));
         mapboxNavigation.addMilestone(new StepMilestone.Builder()
                 .setTrigger(Trigger.eq(TriggerProperty.STEP_INDEX, 0))
                 .setIdentifier(1001).build());
@@ -119,7 +119,7 @@ public class NavigationHelperTest extends BaseTest {
                 .build();
         Context context = mock(Context.class);
         when(context.getApplicationContext()).thenReturn(mock(Context.class));
-        MapboxNavigation mapboxNavigation = new MapboxNavigation(context, ACCESS_TOKEN, options, mock(LocationEngine.class));
+        MapboxNavigation mapboxNavigation = new MapboxNavigation(context, options, mock(LocationEngine.class));
         NavigationLocationUpdate model = NavigationLocationUpdate.create(mock(Location.class), mapboxNavigation);
 
         boolean userOffRoute = isUserOffRoute(model, mock(RouteProgress.class), mock(OffRouteCallback.class));

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessorTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessorTest.java
@@ -31,7 +31,7 @@ public class NavigationRouteProcessorTest extends BaseTest {
     MapboxNavigationOptions options = MapboxNavigationOptions.builder().build();
     Context context = mock(Context.class);
     when(context.getApplicationContext()).thenReturn(context);
-    navigation = new MapboxNavigation(context, ACCESS_TOKEN, options, mock(LocationEngine.class));
+    navigation = new MapboxNavigation(context, options, mock(LocationEngine.class));
     navigation.startNavigation(buildTestDirectionsRoute());
   }
 

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/RouteProcessorThreadListenerTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/RouteProcessorThreadListenerTest.java
@@ -18,7 +18,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 public class RouteProcessorThreadListenerTest {
 
@@ -93,7 +93,7 @@ public class RouteProcessorThreadListenerTest {
 
     listener.onUserOffRoute(mock(Location.class), false);
 
-    verifyZeroInteractions(dispatcher);
+    verifyNoInteractions (dispatcher);
   }
 
   @Test
@@ -115,7 +115,7 @@ public class RouteProcessorThreadListenerTest {
 
     listener.onCheckFasterRoute(mock(Location.class), mock(RouteProgress.class), false);
 
-    verifyZeroInteractions(dispatcher);
+    verifyNoInteractions (dispatcher);
   }
 
   private RouteProcessorThreadListener buildListener(NavigationNotificationProvider provider) {


### PR DESCRIPTION
Fixes #23.

This repo still used jcenter, which recently broke the build. Therefore, we updated the used dependencies, including the build tools and removed jcenter. 

Since the upstream Maplibre removed the accesstoken, we removed them here as well. Since this is a larger change, a review would be welcome, for example @Brammos or @wipfli 