### PR TITLE
Update to Maplibre 9.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 Maplibre welcomes participation and contributions from everyone.
 
-### v1.3.0 - unreleased
+### v2.0.0 - unreleased
 
-- Update Maplibre to 9.5.2
+- Update Maplibre to 9.6.0
 - Updated dependencies of used libs and build tools
 - Removed AccessToken usage
 - Fixed Jitpack Build

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
     ]
 
     version = [
-            mapLibreVersion        : '9.5.2',
+            mapLibreVersion        : '9.6.0',
             mapLibreService        : '5.9.0',
             mapLibreTurf           : '5.9.0',
             mapLibreAnnotations    : '1.0.0',


### PR DESCRIPTION
This PR updates the Maplibre Dependency to 9.6.0