### PR TITLE
Allow to set navigation route processor to arbitrary indices

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessor.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessor.java
@@ -195,7 +195,7 @@ class NavigationRouteProcessor implements OffRouteCallback {
     int legIndex = indices.legIndex();
     int stepIndex = indices.stepIndex();
     int upcomingStepIndex = stepIndex + ONE_INDEX;
-    if(route.legs().size() > legIndex || route.legs().get(legIndex).steps().size() > stepIndex){
+    if(route.legs().size() <= legIndex || route.legs().get(legIndex).steps().size() <= stepIndex){
       // This catches a potential race condition when the route is changed, before the new index is processed
       createFirstIndices(mapboxNavigation);
       return;

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteCallback.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteCallback.java
@@ -10,4 +10,14 @@ public interface OffRouteCallback {
    * In this case, the step index needs to be increased for the next {@link RouteProgress} generation.
    */
   void onShouldIncreaseIndex();
+
+  /**
+   * This callback will fire when the {@link OffRouteDetector} determines that the user
+   * location is close enough to a {@link com.mapbox.api.directions.v5.models.LegStep}.
+   * <p>
+   * This allows to the OffRouteDetector to either go steps back or multple steps forward.
+   * <p>
+   * You can use this for advanced navigation scenarios, by default you probably don't need this.
+   */
+  void onShouldUpdateToIndex(int legIndex, int stepIndex);
 }


### PR DESCRIPTION
This PR allows a client to define indices of the NavigationRouteProcessor. This can be used to go multiple steps forward. 

This can be used if a user wants to skip larger parts of the navigation, for example a loop.

