### PR TITLE
Use navigation options in ToleranceUtils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ Maplibre welcomes participation and contributions from everyone.
 - Updated dependencies of used libs and build tools
 - Removed AccessToken usage
 - Fixed Jitpack Build
+- Use the navigation options instead of constants in ToleranceUtils (used in the offroute detection), if you haven't modified rerouting values in the navigation options, nothing should change
 
-### v1.2.0 - November 21, 2022 
+### v1.2.0 - November 21, 2022
 
-(Please use v1.2.1, as the Release Build failed at Jitpack)
+(Please use a recent commit from Jitpack see [#40](https://github.com/maplibre/maplibre-navigation-android/issues/40), as the Release Build failed at Jitpack)
 
 - Fixed unit tests and updated some build dependencies. 
 - Added Flags for pending intents which are required in Android 31+

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetector.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetector.java
@@ -142,7 +142,7 @@ public class OffRouteDetector extends OffRoute {
 
   private double createOffRouteRadius(Location location, RouteProgress routeProgress,
                                       MapboxNavigationOptions options, Point currentPoint) {
-    double dynamicTolerance = dynamicRerouteDistanceTolerance(currentPoint, routeProgress);
+    double dynamicTolerance = dynamicRerouteDistanceTolerance(currentPoint, routeProgress, options);
     double accuracyTolerance = location.getAccuracy() * options.deadReckoningTimeInterval();
     return Math.max(dynamicTolerance, accuracyTolerance);
   }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/ToleranceUtilsTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/ToleranceUtilsTest.java
@@ -6,6 +6,7 @@ import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.Point;
 import com.mapbox.geojson.utils.PolylineUtils;
 import com.mapbox.services.android.navigation.v5.BaseTest;
+import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigationOptions;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.turf.TurfConstants;
 import com.mapbox.turf.TurfMeasurement;
@@ -26,7 +27,7 @@ public class ToleranceUtilsTest extends BaseTest {
     List<Point> stepPoints = PolylineUtils.decode(route.geometry(), PRECISION_6);
     Point midPoint = TurfMeasurement.midpoint(stepPoints.get(0), stepPoints.get(1));
 
-    double tolerance = ToleranceUtils.dynamicRerouteDistanceTolerance(midPoint, routeProgress);
+    double tolerance = ToleranceUtils.dynamicRerouteDistanceTolerance(midPoint, routeProgress, MapboxNavigationOptions.builder().build());
 
     assertEquals(25.0, tolerance, DELTA);
   }
@@ -40,7 +41,7 @@ public class ToleranceUtilsTest extends BaseTest {
     LineString lineString = LineString.fromPolyline(route.geometry(), Constants.PRECISION_6);
     Point closePoint = TurfMeasurement.along(lineString, distanceToIntersection, TurfConstants.UNIT_METERS);
 
-    double tolerance = ToleranceUtils.dynamicRerouteDistanceTolerance(closePoint, routeProgress);
+    double tolerance = ToleranceUtils.dynamicRerouteDistanceTolerance(closePoint, routeProgress, MapboxNavigationOptions.builder().build());
 
     assertEquals(50.0, tolerance, DELTA);
   }
@@ -53,7 +54,7 @@ public class ToleranceUtilsTest extends BaseTest {
     LineString lineString = LineString.fromPolyline(route.geometry(), Constants.PRECISION_6);
     Point closePoint = TurfMeasurement.along(lineString, distanceToIntersection, TurfConstants.UNIT_METERS);
 
-    double tolerance = ToleranceUtils.dynamicRerouteDistanceTolerance(closePoint, routeProgress);
+    double tolerance = ToleranceUtils.dynamicRerouteDistanceTolerance(closePoint, routeProgress, MapboxNavigationOptions.builder().build());
 
     assertEquals(50.0, tolerance, DELTA);
   }


### PR DESCRIPTION
This PR moves the usage of navigation options in ToleranceUtils. 

If you haven't changed the default values from the navigation options, nothing should change, if you have changed the values, the code in the OffrouteDetector did not worked correctly as the constants were used instead of the specified values.