### PR TITLE
Central configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ Maplibre welcomes participation and contributions from everyone.
 
 ### v2.0.1 - unreleased
 
+- Sample app: Moved all configurations to a central place [#57](https://github.com/maplibre/maplibre-navigation-android/pull/57)
+  > **Note**
+  > Please delete your existing `app/main/res/values/developer-config.xml` to generate the new one or copy following content to your existing file:
+  ```xml
+  <?xml version="1.0" encoding="utf-8"?>
+  <resources>
+      <!-- Your navigation base url (example: https://api.mapbox.com) (-->
+      <string name="base_url" translatable="false">https://api.mapbox.com</string>
+      <!-- Your Mapbox access token (example: pk.abc...) -->
+      <string name="mapbox_access_token" translatable="false">YOUR_MAPBOX_ACCESS_TOKEN_GOES_HERE</string>
+      <!-- Map tile provider for light design (example: https://api.maptiler.com/maps/basic-v2/style.json?key=...) -->
+      <string name="map_style_light" translatable="false"></string>
+      <!-- Map tile provider for dark design (example: "https://api.maptiler.com/maps/basic-v2-dark/style.json?key=...) -->
+      <string name="map_style_dark" translatable="false"></string>
+  </resources>
+  ```
 - Fix memory leak in Navigation Service
 
 ### v2.0.0 - March 21, 2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Maplibre welcomes participation and contributions from everyone.
 ### v2.0.1 - unreleased
 
 - Sample app: Moved all configurations to a central place [#57](https://github.com/maplibre/maplibre-navigation-android/pull/57)
-  > **Note**
+  > **Note**  
   > Please delete your existing `app/main/res/values/developer-config.xml` to generate the new one or copy following content to your existing file:
   ```xml
   <?xml version="1.0" encoding="utf-8"?>

--- a/README.md
+++ b/README.md
@@ -89,8 +89,7 @@ Step 2. Add the dependency
   :dependencies [[com.github.maplibre/maplibre-navigation-android "2.0.0"]]	
 ```
 
-Optional (you can also leave it as an empty String):
-To run the [sample code](#sample-code) on a device or emulator, include your [developer access token](https://www.mapbox.com/help/define-access-token/) in `developer-config.xml` found in the project. 
+To run the [sample code](#sample-code) on a device or emulator, include your [Mapbox access token](https://www.mapbox.com/help/define-access-token/) and map tile provider URL in `developer-config.xml` found in the project. 
 
 # Getting Help
 

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/MockNavigationActivity.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/MockNavigationActivity.kt
@@ -25,9 +25,6 @@ import com.mapbox.mapboxsdk.location.modes.RenderMode
 import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback
 import com.mapbox.mapboxsdk.maps.Style
-import com.mapbox.services.android.navigation.testapp.NavigationSettings.ACCESS_TOKEN
-import com.mapbox.services.android.navigation.testapp.NavigationSettings.BASE_URL
-import com.mapbox.services.android.navigation.testapp.NavigationSettings.STYLE_URL
 import com.mapbox.services.android.navigation.testapp.databinding.ActivityMockNavigationBinding
 import com.mapbox.services.android.navigation.v5.instruction.Instruction
 import com.mapbox.services.android.navigation.v5.location.replay.ReplayRouteLocationEngine
@@ -145,7 +142,7 @@ class MockNavigationActivity :
 
     override fun onMapReady(mapboxMap: MapboxMap) {
         this.mapboxMap = mapboxMap
-        mapboxMap.setStyle(Style.Builder().fromUri(STYLE_URL)) { style ->
+        mapboxMap.setStyle(Style.Builder().fromUri(getString(R.string.map_style_light))) { style ->
             enableLocationComponent(style)
         }
 
@@ -225,12 +222,12 @@ class MockNavigationActivity :
         }
 
         val navigationRouteBuilder = NavigationRoute.builder(this).apply {
-            this.accessToken(ACCESS_TOKEN)
+            this.accessToken(getString(R.string.mapbox_access_token))
             this.origin(origin)
             this.destination(destination)
             this.voiceUnits(DirectionsCriteria.METRIC)
             this.alternatives(true)
-            this.baseUrl(BASE_URL)
+            this.baseUrl(getString(R.string.base_url))
         }
 
         navigationRouteBuilder.build().getRoute(object : Callback<DirectionsResponse> {

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/NavigationApplication.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/NavigationApplication.java
@@ -9,9 +9,6 @@ import timber.log.Timber;
 
 public class NavigationApplication extends Application {
 
-  private static final String LOG_TAG = NavigationApplication.class.getSimpleName();
-  private static final String DEFAULT_MAPBOX_ACCESS_TOKEN = "YOUR_MAPBOX_ACCESS_TOKEN_GOES_HERE";
-
   @Override
   public void onCreate() {
     super.onCreate();

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/NavigationSettings.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/NavigationSettings.kt
@@ -1,9 +1,0 @@
-package com.mapbox.services.android.navigation.testapp
-
-object NavigationSettings {
-    const val STYLE_URL = "YOUR STYLE URL HERE"
-    const val BASE_URL = "YOUR BASE URL HERE"
-    const val ACCESS_TOKEN = "pk.0"
-
-    //Hint: Also apply style urls to TestNavigationViewDark and TestNavigationViewLight in styles.xml
-}

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/NavigationUIActivity.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/NavigationUIActivity.kt
@@ -23,9 +23,6 @@ import com.mapbox.mapboxsdk.location.modes.RenderMode
 import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback
 import com.mapbox.mapboxsdk.maps.Style
-import com.mapbox.services.android.navigation.testapp.NavigationSettings.ACCESS_TOKEN
-import com.mapbox.services.android.navigation.testapp.NavigationSettings.BASE_URL
-import com.mapbox.services.android.navigation.testapp.NavigationSettings.STYLE_URL
 import com.mapbox.services.android.navigation.testapp.databinding.ActivityMockNavigationBinding
 import com.mapbox.services.android.navigation.testapp.databinding.ActivityNavigationUiBinding
 import com.mapbox.services.android.navigation.ui.v5.NavigationLauncher
@@ -104,7 +101,7 @@ class NavigationUIActivity :
 
     override fun onMapReady(mapboxMap: MapboxMap) {
         this.mapboxMap = mapboxMap
-        mapboxMap.setStyle(Style.Builder().fromUri(STYLE_URL)) { style ->
+        mapboxMap.setStyle(Style.Builder().fromUri(getString(R.string.map_style_light))) { style ->
             enableLocationComponent(style)
         }
 
@@ -182,13 +179,13 @@ class NavigationUIActivity :
         }
 
         val navigationRouteBuilder = NavigationRoute.builder(this).apply {
-            this.accessToken(ACCESS_TOKEN)
+            this.accessToken(getString(R.string.mapbox_access_token))
             this.origin(origin)
             this.destination(destination)
             this.voiceUnits(DirectionsCriteria.METRIC)
             this.alternatives(true)
             this.profile("fastest")
-            this.baseUrl(BASE_URL)
+            this.baseUrl(getString(R.string.base_url))
         }
 
         navigationRouteBuilder.build().getRoute(object : Callback<DirectionsResponse> {

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -47,16 +47,10 @@
     </style>
 
     <style name="TestNavigationViewDark" parent="NavigationViewDark">
-        <!-- Map style URL -->
-        <item name="navigationViewMapStyle">
-            YOUR STYLE URL HERE
-        </item>
+        <item name="navigationViewMapStyle">@string/map_style_dark</item>
     </style>
 
     <style name="TestNavigationViewLight" parent="NavigationViewLight">
-        <!-- Map style URL -->
-        <item name="navigationViewMapStyle">
-            YOUR STYLE URL HERE
-        </item>
+        <item name="navigationViewMapStyle">@string/map_style_light</item>
     </style>
 </resources>

--- a/gradle/developer-config.gradle
+++ b/gradle/developer-config.gradle
@@ -3,21 +3,28 @@
 //
 
 task accessToken {
-  def tokenFile = new File("${projectDir}/src/main/res/values/developer-config.xml")
-  if (!tokenFile.exists()) {
-    String mapboxAccessToken = "$System.env.MAPBOX_ACCESS_TOKEN"
-    if (mapboxAccessToken == "null") {
-      System.out.println("You should set the MAPBOX_ACCESS_TOKEN environment variable.")
-      mapboxAccessToken = "YOUR_MAPBOX_ACCESS_TOKEN_GOES_HERE"
+    def tokenFile = new File("${projectDir}/src/main/res/values/developer-config.xml")
+    if (!tokenFile.exists()) {
+        String mapboxAccessToken = "$System.env.MAPBOX_ACCESS_TOKEN"
+        if (mapboxAccessToken == "null") {
+            System.out.println("You should set the MAPBOX_ACCESS_TOKEN environment variable.")
+            mapboxAccessToken = "YOUR_MAPBOX_ACCESS_TOKEN_GOES_HERE"
+        }
+        String tokenFileContents = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                "<resources>\n" +
+                "    <!-- Your navigation base url (example: https://api.mapbox.com) (-->\n" +
+                "    <string name=\"base_url\" translatable=\"false\">https://api.mapbox.com</string>\n" +
+                "    <!-- Your Mapbox access token (example: pk.abc...) -->\n" +
+                "    <string name=\"mapbox_access_token\" translatable=\"false\">" + mapboxAccessToken + "</string>\n" +
+                "    <!-- Map tile provider for light design (example: https://api.maptiler.com/maps/basic-v2/style.json?key=...) -->\n" +
+                "    <string name=\"map_style_light\" translatable=\"false\"></string>\n" +
+                "    <!-- Map tile provider for dark design (example: \"https://api.maptiler.com/maps/basic-v2-dark/style.json?key=...) -->\n" +
+                "    <string name=\"map_style_dark\" translatable=\"false\"></string>\n" +
+                "</resources>"
+        tokenFile.write(tokenFileContents)
     }
-    String tokenFileContents = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
-      "<resources>\n" +
-      "    <string name=\"mapbox_access_token\">" + mapboxAccessToken + "</string>\n" +
-      "</resources>"
-    tokenFile.write(tokenFileContents)
-  }
 }
 
 gradle.projectsEvaluated {
-  preBuild.dependsOn('accessToken')
+    preBuild.dependsOn('accessToken')
 }


### PR DESCRIPTION
Starting with the sample app is very confusing. There were three places that need to configure to get started.

1. `developer-config.xml`
2. `styles.xml`
3. `NavigationSettings.kt`

I choose the existing `developer-config.xml` to be the complete configuration file. 

A good alternative is to generate `BuildConfig` variables or string resources on Gradle build script. The values can be fetched  from `findProperty(...)`. So the user can use  environment variables or `gradle.properties` to set his fields.

Give me feedback if you prefer the here implemented solution or the build script one. For me it was first only important that they are central.