### PR TITLE
Improve off route detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Maplibre welcomes participation and contributions from everyone.
 
 ### v2.0.1 - unreleased
 
+- Mark unused option `maximumDistanceOffRoute` as deprecated [#65](https://github.com/maplibre/maplibre-navigation-android/pull/65)
+- Fix move-away-from-maneuver logic of `OffRouteDetector` [#65](https://github.com/maplibre/maplibre-navigation-android/pull/65)
 - Sample app: Moved all configurations to a central place [#57](https://github.com/maplibre/maplibre-navigation-android/pull/57)
   > **Note**  
   > Please delete your existing `app/main/res/values/developer-config.xml` to generate the new one or copy following content to your existing file:

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
@@ -18,6 +18,10 @@ public abstract class MapboxNavigationOptions {
 
   public abstract double maneuverZoneRadius();
 
+  /**
+   * @deprecated has no effect and will be removed in a future release. Use {@link #minimumDistanceBeforeRerouting()} instead.
+   */
+  @Deprecated
   public abstract double maximumDistanceOffRoute();
 
   public abstract double deadReckoningTimeInterval();
@@ -66,6 +70,10 @@ public abstract class MapboxNavigationOptions {
 
     public abstract Builder maneuverZoneRadius(double maneuverZoneRadius);
 
+    /**
+     * @deprecated has no effect and will be removed in a future release. Use {@link #minimumDistanceBeforeRerouting()} instead.
+     */
+    @Deprecated
     public abstract Builder maximumDistanceOffRoute(double maximumDistanceOffRoute);
 
     public abstract Builder deadReckoningTimeInterval(double deadReckoningTimeInterval);

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
@@ -48,6 +48,12 @@ public abstract class MapboxNavigationOptions {
 
   public abstract double minimumDistanceBeforeRerouting();
 
+  /**
+   * Minimum distance in meters that the user must travel in the correct direction before the
+   * off-route logic recognizes the user is back on the right direction
+   */
+  public abstract double offRouteMinimumDistanceMetersBeforeRightDirection();
+
   public abstract boolean isDebugLoggingEnabled();
 
   @Nullable
@@ -100,6 +106,12 @@ public abstract class MapboxNavigationOptions {
 
     public abstract Builder minimumDistanceBeforeRerouting(double distanceInMeters);
 
+    /**
+     * Minimum distance in meters that the user must travel in the correct direction before the
+     * off-route logic recognizes the user is back on the right direction
+     */
+    public abstract Builder offRouteMinimumDistanceMetersBeforeRightDirection(double distanceInMeters);
+
     public abstract Builder isDebugLoggingEnabled(boolean debugLoggingEnabled);
 
     public abstract Builder navigationNotification(NavigationNotification notification);
@@ -128,6 +140,7 @@ public abstract class MapboxNavigationOptions {
       .manuallyEndNavigationUponCompletion(false)
       .defaultMilestonesEnabled(true)
       .minimumDistanceBeforeRerouting(NavigationConstants.MINIMUM_DISTANCE_BEFORE_REROUTING)
+      .offRouteMinimumDistanceMetersBeforeRightDirection(NavigationConstants.OFF_ROUTE_MINIMUM_DISTANCE_METERS_BEFORE_RIGHT_DIRECTION)
       .metersRemainingTillArrival(NavigationConstants.METERS_REMAINING_TILL_ARRIVAL)
       .isFromNavigationUi(false)
       .isDebugLoggingEnabled(false)

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
@@ -49,6 +49,12 @@ public abstract class MapboxNavigationOptions {
   public abstract double minimumDistanceBeforeRerouting();
 
   /**
+   * Minimum distance in meters that the user must travel in the wrong direction before the
+   * off-route logic recognizes the user is moving away from upcoming maneuver
+   */
+  public abstract double offRouteMinimumDistanceMetersBeforeWrongDirection();
+
+  /**
    * Minimum distance in meters that the user must travel in the correct direction before the
    * off-route logic recognizes the user is back on the right direction
    */
@@ -107,6 +113,12 @@ public abstract class MapboxNavigationOptions {
     public abstract Builder minimumDistanceBeforeRerouting(double distanceInMeters);
 
     /**
+     * Minimum distance in meters that the user must travel in the wrong direction before the
+     * off-route logic recognizes the user is moving away from upcoming maneuver
+     */
+    public abstract Builder offRouteMinimumDistanceMetersBeforeWrongDirection(double distanceInMeters);
+
+    /**
      * Minimum distance in meters that the user must travel in the correct direction before the
      * off-route logic recognizes the user is back on the right direction
      */
@@ -140,6 +152,7 @@ public abstract class MapboxNavigationOptions {
       .manuallyEndNavigationUponCompletion(false)
       .defaultMilestonesEnabled(true)
       .minimumDistanceBeforeRerouting(NavigationConstants.MINIMUM_DISTANCE_BEFORE_REROUTING)
+      .offRouteMinimumDistanceMetersBeforeWrongDirection(NavigationConstants.OFF_ROUTE_MINIMUM_DISTANCE_METERS_BEFORE_WRONG_DIRECTION)
       .offRouteMinimumDistanceMetersBeforeRightDirection(NavigationConstants.OFF_ROUTE_MINIMUM_DISTANCE_METERS_BEFORE_RIGHT_DIRECTION)
       .metersRemainingTillArrival(NavigationConstants.METERS_REMAINING_TILL_ARRIVAL)
       .isFromNavigationUi(false)

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
@@ -80,8 +80,10 @@ public final class NavigationConstants {
      * Maximum number of meters the user can travel away from step before the
      * {@link OffRouteListener}'s called.
      *
+     * @deprecated has no effect and will be removed in a future release.
      * @since 0.2.0
      */
+    @Deprecated
     static final double MAXIMUM_DISTANCE_BEFORE_OFF_ROUTE = 20;
 
     /**

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
@@ -123,6 +123,12 @@ public final class NavigationConstants {
 
     public static final double MINIMUM_BACKUP_DISTANCE_FOR_OFF_ROUTE = 50;
 
+    /**
+     * Minimum distance in meters that the user must travel in the correct direction before the
+     * off-route logic recognizes the user is back on the right direction
+     */
+    public static final double OFF_ROUTE_MINIMUM_DISTANCE_METERS_BEFORE_RIGHT_DIRECTION = 20;
+
     public static final double MINIMUM_DISTANCE_BEFORE_REROUTING = 50;
 
     /**

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
@@ -121,7 +121,11 @@ public final class NavigationConstants {
      */
     public static final double METERS_REMAINING_TILL_ARRIVAL = 40;
 
-    public static final double MINIMUM_BACKUP_DISTANCE_FOR_OFF_ROUTE = 50;
+    /**
+     * Minimum distance in meters that the user must travel in the wrong direction before the
+     * off-route logic recognizes the user is moving away from upcoming maneuver
+     */
+    public static final double OFF_ROUTE_MINIMUM_DISTANCE_METERS_BEFORE_WRONG_DIRECTION = 50;
 
     /**
      * Minimum distance in meters that the user must travel in the correct direction before the

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetector.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetector.java
@@ -225,7 +225,7 @@ public class OffRouteDetector extends OffRoute {
 
     if (distancesAwayFromManeuver.isEmpty()) {
       // No move-away positions before, add the current one to history stack
-      distancesAwayFromManeuver.add((int) userDistanceToManeuver);
+      distancesAwayFromManeuver.addLast((int) userDistanceToManeuver);
     } else if ((int) userDistanceToManeuver > distancesAwayFromManeuver.getLast()) {
       // If distance to maneuver increased (wrong way), add new position to history stack
 
@@ -233,7 +233,7 @@ public class OffRouteDetector extends OffRoute {
         // We replace the first one, in order to keep the history with the last one
         distancesAwayFromManeuver.removeLast();
       }
-      distancesAwayFromManeuver.add((int) userDistanceToManeuver);
+      distancesAwayFromManeuver.addLast((int) userDistanceToManeuver);
     } else if ((int) userDistanceToManeuver < distancesAwayFromManeuver.getLast()) {
       // If distance to maneuver decreased (right way) clean history
       distancesAwayFromManeuver.clear();

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetector.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetector.java
@@ -221,20 +221,20 @@ public class OffRouteDetector extends OffRoute {
     }
 
     LineString remainingStepLineString = TurfMisc.lineSlice(userPointOnStep, maneuverPoint, stepLineString);
-    double userDistanceToManeuver = TurfMeasurement.length(remainingStepLineString, TurfConstants.UNIT_METERS);
+    int userDistanceToManeuver = (int) TurfMeasurement.length(remainingStepLineString, TurfConstants.UNIT_METERS);
 
     if (distancesAwayFromManeuver.isEmpty()) {
       // No move-away positions before, add the current one to history stack
-      distancesAwayFromManeuver.addLast((int) userDistanceToManeuver);
-    } else if ((int) userDistanceToManeuver > distancesAwayFromManeuver.getLast()) {
+      distancesAwayFromManeuver.addLast(userDistanceToManeuver);
+    } else if (userDistanceToManeuver > distancesAwayFromManeuver.getLast()) {
       // If distance to maneuver increased (wrong way), add new position to history stack
 
       if (distancesAwayFromManeuver.size() >= 3) {
         // We replace the first one, in order to keep the history with the last one
         distancesAwayFromManeuver.removeLast();
       }
-      distancesAwayFromManeuver.addLast((int) userDistanceToManeuver);
-    } else if ((int) userDistanceToManeuver < distancesAwayFromManeuver.getLast()) {
+      distancesAwayFromManeuver.addLast(userDistanceToManeuver);
+    } else if (userDistanceToManeuver < distancesAwayFromManeuver.getLast()) {
       // If distance to maneuver decreased (right way) clean history
       distancesAwayFromManeuver.clear();
     }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetector.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetector.java
@@ -12,7 +12,6 @@ import com.mapbox.turf.TurfConstants;
 import com.mapbox.turf.TurfMeasurement;
 import com.mapbox.turf.TurfMisc;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.MINIMUM_BACKUP_DISTANCE_FOR_OFF_ROUTE;

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetector.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetector.java
@@ -14,7 +14,6 @@ import com.mapbox.turf.TurfMisc;
 
 import java.util.List;
 
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.MINIMUM_BACKUP_DISTANCE_FOR_OFF_ROUTE;
 import static com.mapbox.services.android.navigation.v5.utils.MeasurementUtils.userTrueDistanceFromStep;
 import static com.mapbox.services.android.navigation.v5.utils.ToleranceUtils.dynamicRerouteDistanceTolerance;
 
@@ -247,7 +246,7 @@ public class OffRouteDetector extends OffRoute {
     // Minimum 3 position updates in the wrong way are required before an off-route can occur
     if (distancesAwayFromManeuver.size() >= 3) {
       // Check for minimum distance traveled
-      return (distancesAwayFromManeuver.getLast() - distancesAwayFromManeuver.getFirst()) > MINIMUM_BACKUP_DISTANCE_FOR_OFF_ROUTE;
+      return (distancesAwayFromManeuver.getLast() - distancesAwayFromManeuver.getFirst()) > options.offRouteMinimumDistanceMetersBeforeWrongDirection();
     }
 
     return false;

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetector.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetector.java
@@ -191,61 +191,61 @@ public class OffRouteDetector extends OffRoute {
     return false;
   }
 
-    /**
-     * Checks to see if the current point is moving away from the maneuver.
-     * <p>
-     * Minimum three location updates and minimum of 50 meters away from the maneuver are required
-     * to fire an off-route event. This parameters be considered that the user is no longer going in the right direction.
-     *
-     * @param routeProgress             for the upcoming step maneuver
-     * @param distancesAwayFromManeuver current stack of distances away
-     * @param stepPoints                current step points being traveled along
-     * @param currentPoint              to determine if moving away or not
-     * @return true if moving away from maneuver, false if not
-     */
-    private static boolean movingAwayFromManeuver(RouteProgress routeProgress,
-                                                  List<Integer> distancesAwayFromManeuver,
-                                                  List<Point> stepPoints,
-                                                  Point currentPoint) {
-        boolean invalidUpcomingStep = routeProgress.currentLegProgress().upComingStep() == null;
-        boolean invalidStepPointSize = stepPoints.size() < TWO_POINTS;
-        if (invalidUpcomingStep || invalidStepPointSize) {
-            return false;
-        }
-
-        LineString stepLineString = LineString.fromLngLats(stepPoints);
-        Point maneuverPoint = stepPoints.get(stepPoints.size() - 1);
-        Point userPointOnStep = (Point) TurfMisc.nearestPointOnLine(currentPoint, stepPoints).geometry();
-
-        if (userPointOnStep == null || maneuverPoint.equals(userPointOnStep)) {
-            return false;
-        }
-
-        LineString remainingStepLineString = TurfMisc.lineSlice(userPointOnStep, maneuverPoint, stepLineString);
-        double userDistanceToManeuver = TurfMeasurement.length(remainingStepLineString, TurfConstants.UNIT_METERS);
-
-        if (distancesAwayFromManeuver.isEmpty()) {
-            // No move-away positions before, add the current one to history stack
-            distancesAwayFromManeuver.add((int) userDistanceToManeuver);
-        } else if ((int) userDistanceToManeuver > distancesAwayFromManeuver.get(distancesAwayFromManeuver.size() - 1)) {
-            // If distance to maneuver increased (wrong way), add new position to history stack
-            distancesAwayFromManeuver.add((int) userDistanceToManeuver);
-        } else if ((int) userDistanceToManeuver < distancesAwayFromManeuver.get(distancesAwayFromManeuver.size() - 1)) {
-            // If distance to maneuver decreased (right way) clean history
-            distancesAwayFromManeuver.clear();
-        }
-
-        // Minimum 3 position updates in the wrong way are required before an off-route can occur
-        if (distancesAwayFromManeuver.size() >= 3) {
-            // Check for minimum distance traveled
-            return (distancesAwayFromManeuver.get(distancesAwayFromManeuver.size() - 1) -
-                    distancesAwayFromManeuver.get(0)) > MINIMUM_BACKUP_DISTANCE_FOR_OFF_ROUTE;
-        }
-
-        return false;
+  /**
+   * Checks to see if the current point is moving away from the maneuver.
+   * <p>
+   * Minimum three location updates and minimum of 50 meters away from the maneuver are required
+   * to fire an off-route event. This parameters be considered that the user is no longer going in the right direction.
+   *
+   * @param routeProgress             for the upcoming step maneuver
+   * @param distancesAwayFromManeuver current stack of distances away
+   * @param stepPoints                current step points being traveled along
+   * @param currentPoint              to determine if moving away or not
+   * @return true if moving away from maneuver, false if not
+   */
+  private static boolean movingAwayFromManeuver(RouteProgress routeProgress,
+                                                List<Integer> distancesAwayFromManeuver,
+                                                List<Point> stepPoints,
+                                                Point currentPoint) {
+    boolean invalidUpcomingStep = routeProgress.currentLegProgress().upComingStep() == null;
+    boolean invalidStepPointSize = stepPoints.size() < TWO_POINTS;
+    if (invalidUpcomingStep || invalidStepPointSize) {
+      return false;
     }
 
-    private void updateLastReroutePoint(Location location) {
+    LineString stepLineString = LineString.fromLngLats(stepPoints);
+    Point maneuverPoint = stepPoints.get(stepPoints.size() - 1);
+    Point userPointOnStep = (Point) TurfMisc.nearestPointOnLine(currentPoint, stepPoints).geometry();
+
+    if (userPointOnStep == null || maneuverPoint.equals(userPointOnStep)) {
+      return false;
+    }
+
+    LineString remainingStepLineString = TurfMisc.lineSlice(userPointOnStep, maneuverPoint, stepLineString);
+    double userDistanceToManeuver = TurfMeasurement.length(remainingStepLineString, TurfConstants.UNIT_METERS);
+
+    if (distancesAwayFromManeuver.isEmpty()) {
+      // No move-away positions before, add the current one to history stack
+      distancesAwayFromManeuver.add((int) userDistanceToManeuver);
+    } else if ((int) userDistanceToManeuver > distancesAwayFromManeuver.get(distancesAwayFromManeuver.size() - 1)) {
+      // If distance to maneuver increased (wrong way), add new position to history stack
+      distancesAwayFromManeuver.add((int) userDistanceToManeuver);
+    } else if ((int) userDistanceToManeuver < distancesAwayFromManeuver.get(distancesAwayFromManeuver.size() - 1)) {
+      // If distance to maneuver decreased (right way) clean history
+      distancesAwayFromManeuver.clear();
+    }
+
+    // Minimum 3 position updates in the wrong way are required before an off-route can occur
+    if (distancesAwayFromManeuver.size() >= 3) {
+      // Check for minimum distance traveled
+      return (distancesAwayFromManeuver.get(distancesAwayFromManeuver.size() - 1) -
+          distancesAwayFromManeuver.get(0)) > MINIMUM_BACKUP_DISTANCE_FOR_OFF_ROUTE;
+    }
+
+    return false;
+  }
+
+  private void updateLastReroutePoint(Location location) {
     lastReroutePoint = Point.fromLngLat(location.getLongitude(), location.getLatitude());
   }
 }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetectorTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetectorTest.java
@@ -211,39 +211,39 @@ public class OffRouteDetectorTest extends BaseTest {
 
     Point lastPointInCurrentStep = coordinates.get(7);
     Location secondLocationUpdate = buildDefaultLocationUpdate(
-            lastPointInCurrentStep.longitude(), lastPointInCurrentStep.latitude()
+      lastPointInCurrentStep.longitude(), lastPointInCurrentStep.latitude()
     );
     boolean isUserOffRouteFirstTry = offRouteDetector.isUserOffRoute(secondLocationUpdate, routeProgress, options);
     assertFalse(isUserOffRouteFirstTry);
 
     Point pointSix = coordinates.get(6);
     Location thirdLocationUpdate = buildDefaultLocationUpdate(
-            pointSix.longitude(), pointSix.latitude()
+      pointSix.longitude(), pointSix.latitude()
     );
     boolean isUserOffRouteSecondTry = offRouteDetector.isUserOffRoute(thirdLocationUpdate, routeProgress, options);
     assertFalse(isUserOffRouteSecondTry);
 
     Location fourthLocationUpdate = buildDefaultLocationUpdate(
-            pointSix.longitude(), pointSix.latitude()
+      pointSix.longitude(), pointSix.latitude()
     );
     boolean isUserOffRouteThirdTry = offRouteDetector.isUserOffRoute(fourthLocationUpdate, routeProgress, options);
     assertFalse(isUserOffRouteThirdTry);
 
     Location fifthLocationUpdate = buildDefaultLocationUpdate(
-            pointSix.longitude(), pointSix.latitude()
+      pointSix.longitude(), pointSix.latitude()
     );
     boolean isUserOffRouteFourthTry = offRouteDetector.isUserOffRoute(fifthLocationUpdate, routeProgress, options);
     assertFalse(isUserOffRouteFourthTry);
 
     Location sixthLocationUpdate = buildDefaultLocationUpdate(
-            pointSix.longitude(), pointSix.latitude()
+      pointSix.longitude(), pointSix.latitude()
     );
     boolean isUserOffRouteFifthTry = offRouteDetector.isUserOffRoute(sixthLocationUpdate, routeProgress, options);
     assertFalse(isUserOffRouteFifthTry);
 
     Point pointFive = coordinates.get(5);
     Location seventhLocationUpdate = buildDefaultLocationUpdate(
-            pointFive.longitude(), pointFive.latitude()
+      pointFive.longitude(), pointFive.latitude()
     );
     boolean isUserOffRouteSixthTry = offRouteDetector.isUserOffRoute(seventhLocationUpdate, routeProgress, options);
     assertFalse(isUserOffRouteSixthTry);

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetectorTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetectorTest.java
@@ -199,6 +199,57 @@ public class OffRouteDetectorTest extends BaseTest {
   }
 
   @Test
+  public void isUserOffRoute_AssertFalseWhenOnRouteMovingAwayButNotFarEnoughFromManeuver() throws Exception {
+    RouteProgress routeProgress = buildDefaultTestRouteProgress();
+    LegStep currentStep = routeProgress.currentLegProgress().currentStep();
+
+    LineString lineString = LineString.fromPolyline(currentStep.geometry(), Constants.PRECISION_6);
+    List<Point> coordinates = lineString.coordinates();
+
+    Location firstLocationUpdate = buildDefaultLocationUpdate(-77.0339782574523, 38.89993519985637);
+    offRouteDetector.isUserOffRoute(firstLocationUpdate, routeProgress, options);
+
+    Point lastPointInCurrentStep = coordinates.get(7);
+    Location secondLocationUpdate = buildDefaultLocationUpdate(
+            lastPointInCurrentStep.longitude(), lastPointInCurrentStep.latitude()
+    );
+    boolean isUserOffRouteFirstTry = offRouteDetector.isUserOffRoute(secondLocationUpdate, routeProgress, options);
+    assertFalse(isUserOffRouteFirstTry);
+
+    Point pointSix = coordinates.get(6);
+    Location thirdLocationUpdate = buildDefaultLocationUpdate(
+            pointSix.longitude(), pointSix.latitude()
+    );
+    boolean isUserOffRouteSecondTry = offRouteDetector.isUserOffRoute(thirdLocationUpdate, routeProgress, options);
+    assertFalse(isUserOffRouteSecondTry);
+
+    Location fourthLocationUpdate = buildDefaultLocationUpdate(
+            pointSix.longitude(), pointSix.latitude()
+    );
+    boolean isUserOffRouteThirdTry = offRouteDetector.isUserOffRoute(fourthLocationUpdate, routeProgress, options);
+    assertFalse(isUserOffRouteThirdTry);
+
+    Location fifthLocationUpdate = buildDefaultLocationUpdate(
+            pointSix.longitude(), pointSix.latitude()
+    );
+    boolean isUserOffRouteFourthTry = offRouteDetector.isUserOffRoute(fifthLocationUpdate, routeProgress, options);
+    assertFalse(isUserOffRouteFourthTry);
+
+    Location sixthLocationUpdate = buildDefaultLocationUpdate(
+            pointSix.longitude(), pointSix.latitude()
+    );
+    boolean isUserOffRouteFifthTry = offRouteDetector.isUserOffRoute(sixthLocationUpdate, routeProgress, options);
+    assertFalse(isUserOffRouteFifthTry);
+
+    Point pointFive = coordinates.get(5);
+    Location seventhLocationUpdate = buildDefaultLocationUpdate(
+            pointFive.longitude(), pointFive.latitude()
+    );
+    boolean isUserOffRouteSixthTry = offRouteDetector.isUserOffRoute(seventhLocationUpdate, routeProgress, options);
+    assertFalse(isUserOffRouteSixthTry);
+  }
+
+  @Test
   public void isUserOffRoute_AssertFalseTwoUpdatesAwayFromManeuverThenOneTowards() throws Exception {
     RouteProgress routeProgress = buildDefaultTestRouteProgress();
     LegStep currentStep = routeProgress.currentLegProgress().currentStep();

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetectorTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetectorTest.java
@@ -247,6 +247,13 @@ public class OffRouteDetectorTest extends BaseTest {
     );
     boolean isUserOffRouteSixthTry = offRouteDetector.isUserOffRoute(seventhLocationUpdate, routeProgress, options);
     assertFalse(isUserOffRouteSixthTry);
+
+    Point pointFour = coordinates.get(4);
+    Location eighthLocationUpdate = buildDefaultLocationUpdate(
+        pointFour.longitude(), pointFour.latitude()
+    );
+    boolean isUserOffRouteSeventhTry = offRouteDetector.isUserOffRoute(eighthLocationUpdate, routeProgress, options);
+    assertFalse(isUserOffRouteSeventhTry);
   }
 
   @Test

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetectorTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetectorTest.java
@@ -257,6 +257,116 @@ public class OffRouteDetectorTest extends BaseTest {
   }
 
   @Test
+  public void isUserOffRoute_AssertTrueWhenOnRouteMovingAwayWithRightDirectionTraveling() throws Exception {
+    RouteProgress routeProgress = buildDefaultTestRouteProgress();
+    LegStep currentStep = routeProgress.currentLegProgress().currentStep();
+
+    LineString lineString = LineString.fromPolyline(currentStep.geometry(), Constants.PRECISION_6);
+    List<Point> coordinates = lineString.coordinates();
+
+    Location firstLocationUpdate = buildDefaultLocationUpdate(-77.0339782574523, 38.89993519985637);
+    offRouteDetector.isUserOffRoute(firstLocationUpdate, routeProgress, options);
+
+    Point lastPointInCurrentStep = coordinates.remove(coordinates.size() - 1);
+    Location secondLocationUpdate = buildDefaultLocationUpdate(
+        lastPointInCurrentStep.longitude(), lastPointInCurrentStep.latitude()
+    );
+    boolean isUserOffRouteFirstTry = offRouteDetector.isUserOffRoute(secondLocationUpdate, routeProgress, options);
+    assertFalse(isUserOffRouteFirstTry);
+
+    Point secondLastPointInCurrentStep = coordinates.remove(coordinates.size() - 1);
+    Location thirdLocationUpdate = buildDefaultLocationUpdate(
+        secondLastPointInCurrentStep.longitude(), secondLastPointInCurrentStep.latitude()
+    );
+    boolean isUserOffRouteSecondTry = offRouteDetector.isUserOffRoute(thirdLocationUpdate, routeProgress, options);
+    assertFalse(isUserOffRouteSecondTry);
+
+    Point thirdLastPointInCurrentStep = coordinates.remove(coordinates.size() - 1);
+    Location fourthLocationUpdate = buildDefaultLocationUpdate(
+        thirdLastPointInCurrentStep.longitude(), thirdLastPointInCurrentStep.latitude()
+    );
+    boolean isUserOffRouteThirdTry = offRouteDetector.isUserOffRoute(fourthLocationUpdate, routeProgress, options);
+    assertFalse(isUserOffRouteThirdTry);
+
+    Point fourthLastPointInCurrentStep = coordinates.remove(coordinates.size() - 1);
+    Location fifthLocationUpdate = buildDefaultLocationUpdate(
+        fourthLastPointInCurrentStep.longitude(), fourthLastPointInCurrentStep.latitude()
+    );
+    boolean isUserOffRouteFourthTry = offRouteDetector.isUserOffRoute(fifthLocationUpdate, routeProgress, options);
+    assertFalse(isUserOffRouteFourthTry);
+
+    Location eighthLocationUpdate = buildDefaultLocationUpdate(
+        secondLastPointInCurrentStep.longitude(), secondLastPointInCurrentStep.latitude()
+    );
+    boolean isUserOffRouteSeventhTry = offRouteDetector.isUserOffRoute(eighthLocationUpdate, routeProgress, options);
+    assertFalse(isUserOffRouteSeventhTry);
+
+    Point fifthLastPointInCurrentStep = coordinates.remove(coordinates.size() - 1);
+    Location sixthLocationUpdate = buildDefaultLocationUpdate(
+        fifthLastPointInCurrentStep.longitude(), fifthLastPointInCurrentStep.latitude()
+    );
+    boolean isUserOffRouteFifthTry = offRouteDetector.isUserOffRoute(sixthLocationUpdate, routeProgress, options);
+    assertFalse(isUserOffRouteFifthTry);
+  }
+
+  @Test
+  public void isUserOffRoute_AssertTrueWhenOnRouteMovingAwayWithNotEnoughRightDirectionTraveling() throws Exception {
+    MapboxNavigationOptions options = this.options.toBuilder()
+      .offRouteMinimumDistanceMetersBeforeRightDirection(60)
+      .build();
+
+    RouteProgress routeProgress = buildDefaultTestRouteProgress();
+    LegStep currentStep = routeProgress.currentLegProgress().currentStep();
+
+    LineString lineString = LineString.fromPolyline(currentStep.geometry(), Constants.PRECISION_6);
+    List<Point> coordinates = lineString.coordinates();
+
+    Location firstLocationUpdate = buildDefaultLocationUpdate(-77.0339782574523, 38.89993519985637);
+    offRouteDetector.isUserOffRoute(firstLocationUpdate, routeProgress, options);
+
+    Point lastPointInCurrentStep = coordinates.remove(coordinates.size() - 1);
+    Location secondLocationUpdate = buildDefaultLocationUpdate(
+      lastPointInCurrentStep.longitude(), lastPointInCurrentStep.latitude()
+    );
+    boolean isUserOffRouteFirstTry = offRouteDetector.isUserOffRoute(secondLocationUpdate, routeProgress, options);
+    assertFalse(isUserOffRouteFirstTry);
+
+    Point secondLastPointInCurrentStep = coordinates.remove(coordinates.size() - 1);
+    Location thirdLocationUpdate = buildDefaultLocationUpdate(
+      secondLastPointInCurrentStep.longitude(), secondLastPointInCurrentStep.latitude()
+    );
+    boolean isUserOffRouteSecondTry = offRouteDetector.isUserOffRoute(thirdLocationUpdate, routeProgress, options);
+    assertFalse(isUserOffRouteSecondTry);
+
+    Point thirdLastPointInCurrentStep = coordinates.remove(coordinates.size() - 1);
+    Location fourthLocationUpdate = buildDefaultLocationUpdate(
+      thirdLastPointInCurrentStep.longitude(), thirdLastPointInCurrentStep.latitude()
+    );
+    boolean isUserOffRouteThirdTry = offRouteDetector.isUserOffRoute(fourthLocationUpdate, routeProgress, options);
+    assertFalse(isUserOffRouteThirdTry);
+
+    Point fourthLastPointInCurrentStep = coordinates.remove(coordinates.size() - 1);
+    Location fifthLocationUpdate = buildDefaultLocationUpdate(
+      fourthLastPointInCurrentStep.longitude(), fourthLastPointInCurrentStep.latitude()
+    );
+    boolean isUserOffRouteFourthTry = offRouteDetector.isUserOffRoute(fifthLocationUpdate, routeProgress, options);
+    assertFalse(isUserOffRouteFourthTry);
+
+    Location eighthLocationUpdate = buildDefaultLocationUpdate(
+      secondLastPointInCurrentStep.longitude(), secondLastPointInCurrentStep.latitude()
+    );
+    boolean isUserOffRouteSeventhTry = offRouteDetector.isUserOffRoute(eighthLocationUpdate, routeProgress, options);
+    assertFalse(isUserOffRouteSeventhTry);
+
+    Point fifthLastPointInCurrentStep = coordinates.remove(coordinates.size() - 1);
+    Location sixthLocationUpdate = buildDefaultLocationUpdate(
+      fifthLastPointInCurrentStep.longitude(), fifthLastPointInCurrentStep.latitude()
+    );
+    boolean isUserOffRouteFifthTry = offRouteDetector.isUserOffRoute(sixthLocationUpdate, routeProgress, options);
+    assertTrue(isUserOffRouteFifthTry);
+  }
+
+  @Test
   public void isUserOffRoute_AssertFalseTwoUpdatesAwayFromManeuverThenOneTowards() throws Exception {
     RouteProgress routeProgress = buildDefaultTestRouteProgress();
     LegStep currentStep = routeProgress.currentLegProgress().currentStep();


### PR DESCRIPTION
This will fix the problems described in #58.

Following things are done
1. Improve `movingAwayFromManeuver` logic.
2. Mark `maximumDistanceOffRoute` as deprecated

Instead of removing `maximumDistanceOffRoute` directly, I marked the option as deprecated, while some projects may already use this in their code.

Let me know if I can adjust something more or you find some problem in my code.