### PR TITLE
Add route snap example

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,10 +22,18 @@
         </activity>
         <activity
             android:name=".NavigationUIActivity"
-            android:label="@string/title_navigation_ui" />
+            android:label="@string/title_navigation_ui">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".MainActivity" />
+        </activity>
         <activity
             android:name=".SnapToRouteNavigationActivity"
-            android:label="@string/title_snap_to_route" />
+            android:label="@string/title_snap_to_route">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".MainActivity" />
+        </activity>
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,9 @@
             android:name=".NavigationUIActivity"
             android:label="@string/title_navigation_ui" />
         <activity
+            android:name=".SnapToRouteNavigationActivity"
+            android:label="@string/title_snap_to_route" />
+        <activity
             android:name=".MainActivity"
             android:exported="true">
             <intent-filter>

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/MainActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/MainActivity.java
@@ -48,6 +48,11 @@ public class MainActivity extends AppCompatActivity implements PermissionsListen
             getString(R.string.description_navigation_ui),
             NavigationUIActivity.class
         ));
+        list.add(new SampleItem(
+            getString(R.string.title_snap_to_route),
+            getString(R.string.description_snap_to_route),
+            SnapToRouteNavigationActivity.class
+        ));
         RecyclerView.Adapter adapter = new MainAdapter(list);
         recyclerView.setAdapter(adapter);
 

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/SnapToRouteNavigationActivity.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/SnapToRouteNavigationActivity.kt
@@ -170,4 +170,36 @@ class SnapToRouteNavigationActivity : AppCompatActivity(), OnMapReadyCallback,
         // Update own location with the snapped location
         locationComponent?.forceLocationUpdate(location)
     }
+
+    override fun onResume() {
+        super.onResume()
+        binding.mapView.onResume()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        binding.mapView.onPause()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        binding.mapView.onStart()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        binding.mapView.onStop()
+    }
+
+    override fun onLowMemory() {
+        super.onLowMemory()
+        binding.mapView.onLowMemory()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        navigation.onDestroy()
+        binding.mapView.onDestroy()
+    }
+
 }

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/SnapToRouteNavigationActivity.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/SnapToRouteNavigationActivity.kt
@@ -1,0 +1,204 @@
+package com.mapbox.services.android.navigation.testapp
+
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
+import android.annotation.SuppressLint
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.location.Location
+import android.os.Build
+import android.os.Bundle
+import android.util.Log
+import android.view.View
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.snackbar.Snackbar
+import com.mapbox.api.directions.v5.DirectionsCriteria
+import com.mapbox.api.directions.v5.models.DirectionsResponse
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.geojson.Point
+import com.mapbox.mapboxsdk.annotations.MarkerOptions
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory
+import com.mapbox.mapboxsdk.geometry.LatLng
+import com.mapbox.mapboxsdk.location.LocationComponent
+import com.mapbox.mapboxsdk.location.LocationComponentActivationOptions
+import com.mapbox.mapboxsdk.location.OnLocationCameraTransitionListener
+import com.mapbox.mapboxsdk.location.modes.CameraMode
+import com.mapbox.mapboxsdk.location.modes.RenderMode
+import com.mapbox.mapboxsdk.maps.MapboxMap
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback
+import com.mapbox.mapboxsdk.maps.Style
+import com.mapbox.services.android.navigation.testapp.databinding.ActivityMockNavigationBinding
+import com.mapbox.services.android.navigation.testapp.databinding.ActivitySnapToRouteNavigationBinding
+import com.mapbox.services.android.navigation.v5.instruction.Instruction
+import com.mapbox.services.android.navigation.v5.location.replay.ReplayRouteLocationEngine
+import com.mapbox.services.android.navigation.v5.milestone.*
+import com.mapbox.services.android.navigation.v5.navigation.*
+import com.mapbox.services.android.navigation.v5.offroute.OffRouteListener
+import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress
+import com.mapbox.turf.TurfConstants
+import com.mapbox.turf.TurfMeasurement
+import okhttp3.Request
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import timber.log.Timber
+import java.lang.ref.WeakReference
+
+//TODO: describe what this needed for enable route snapping
+/**
+ *
+ */
+class SnapToRouteNavigationActivity : AppCompatActivity(), OnMapReadyCallback,
+    ProgressChangeListener {
+
+    private lateinit var binding: ActivitySnapToRouteNavigationBinding
+    private lateinit var mapboxMap: MapboxMap
+    private var locationEngine: ReplayRouteLocationEngine = ReplayRouteLocationEngine()
+    private lateinit var navigation: MapboxNavigation
+    private var route: DirectionsRoute? = null
+    private var navigationMapRoute: NavigationMapRoute? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        binding = ActivitySnapToRouteNavigationBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        navigation = MapboxNavigation(
+            this, MapboxNavigationOptions.builder()
+                .snapToRoute(true)
+                .build()
+        ).apply {
+            addProgressChangeListener(this@SnapToRouteNavigationActivity)
+        }
+
+        binding.mapView.apply {
+            onCreate(savedInstanceState)
+            getMapAsync(this@SnapToRouteNavigationActivity)
+        }
+
+        //TODO: hide when started ?! start automatically..
+        //TODO: follow again button
+        binding.btnStartNavigation.setOnClickListener {
+            startRouting()
+        }
+    }
+
+    private var locationComponent: LocationComponent? = null
+
+    override fun onMapReady(mapboxMap: MapboxMap) {
+        this.mapboxMap = mapboxMap
+        mapboxMap.setStyle(Style.Builder().fromUri(getString(R.string.map_style_light))) { style ->
+            enableLocationComponent(style)
+        }
+
+        navigationMapRoute = NavigationMapRoute(navigation, binding.mapView, mapboxMap)
+        calculateRoute()
+    }
+
+    @SuppressWarnings("MissingPermission")
+    private fun enableLocationComponent(style: Style) {
+        locationComponent = mapboxMap.locationComponent
+        mapboxMap.locationComponent.activateLocationComponent(
+            LocationComponentActivationOptions.builder(
+                this,
+                style,
+            )
+                .useDefaultLocationEngine(false)
+                .build()
+        )
+
+        followLocation()
+
+        mapboxMap.locationComponent.isLocationComponentEnabled = true
+    }
+
+    private fun followLocation() {
+        if (!mapboxMap.locationComponent.isLocationComponentActivated) {
+            return
+        }
+
+        mapboxMap.locationComponent.renderMode = RenderMode.GPS
+        mapboxMap.locationComponent.setCameraMode(
+            CameraMode.TRACKING_GPS,
+            object :
+                OnLocationCameraTransitionListener {
+                override fun onLocationCameraTransitionFinished(cameraMode: Int) {
+                    mapboxMap.locationComponent.zoomWhileTracking(17.0)
+                    mapboxMap.locationComponent.tiltWhileTracking(60.0)
+
+//                    binding.btnFollow.animate()
+//                        .alpha(0f)
+//                        .setDuration(300)
+//                        .setListener(object : AnimatorListenerAdapter() {
+//                            override fun onAnimationEnd(
+//                                animation: Animator,
+//                                isReverse: Boolean
+//                            ) {
+//                                super.onAnimationEnd(animation, isReverse)
+//                                binding.btnFollow.isVisible = false
+//                            }
+//
+//                            override fun onAnimationEnd(animation: Animator) {
+//                                super.onAnimationEnd(animation)
+//                                binding.btnFollow.isVisible = false
+//                            }
+//                        })
+                }
+
+                override fun onLocationCameraTransitionCanceled(cameraMode: Int) {}
+            }
+        )
+    }
+
+    private fun calculateRoute() {
+        val navigationRouteBuilder = NavigationRoute.builder(this).apply {
+            this.accessToken(getString(R.string.mapbox_access_token))
+            this.origin(Point.fromLngLat(9.7536318, 52.3717979))
+            this.addWaypoint(Point.fromLngLat(9.741052, 52.360496))
+            this.destination(Point.fromLngLat(9.756259, 52.342620))
+            this.voiceUnits(DirectionsCriteria.METRIC)
+            this.alternatives(true)
+            this.baseUrl(getString(R.string.base_url))
+        }
+
+        navigationRouteBuilder.build().getRoute(object : Callback<DirectionsResponse> {
+            override fun onResponse(
+                call: Call<DirectionsResponse>,
+                response: Response<DirectionsResponse>,
+            ) {
+                Timber.d("Url: %s", (call.request() as Request).url.toString())
+                response.body()?.let { response ->
+                    if (response.routes().isNotEmpty()) {
+                        val directionsRoute = response.routes().first()
+                        this@SnapToRouteNavigationActivity.route = directionsRoute
+                        navigationMapRoute?.addRoutes(response.routes())
+                    }
+                }
+            }
+
+            override fun onFailure(call: Call<DirectionsResponse>, throwable: Throwable) {
+                Timber.e(throwable, "onFailure: navigation.getRoute()")
+            }
+        })
+    }
+
+    fun startRouting() {
+        route?.let { route ->
+            locationEngine.also { locationEngine ->
+                locationEngine.assign(route)
+                navigation.locationEngine = locationEngine
+                navigation.startNavigation(route)
+            }
+        }
+    }
+
+    override fun onProgressChange(location: Location, routeProgress: RouteProgress) {
+        Log.d("debug", "bearing: ${location.bearing}")
+        // Update own location with the snapped location
+        locationComponent?.forceLocationUpdate(location)
+    }
+}

--- a/app/src/main/res/layout/activity_snap_to_route_navigation.xml
+++ b/app/src/main/res/layout/activity_snap_to_route_navigation.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MockNavigationActivity">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.0"
+        app:maplibre_cameraTargetLat="52.3585999"
+        app:maplibre_cameraTargetLng="9.7481622"
+        app:maplibre_cameraZoom="12"
+        app:maplibre_enableTilePrefetch="true"
+        app:maplibre_enableZMediaOverlay="true"
+        app:maplibre_renderTextureMode="true"
+        app:maplibre_renderTextureTranslucentSurface="true"
+        app:maplibre_uiAttribution="false"
+        app:maplibre_uiCompass="false"
+        app:maplibre_uiDoubleTapGestures="true"
+        app:maplibre_uiLogo="false"
+        app:maplibre_uiRotateGestures="true"
+        app:maplibre_uiScrollGestures="true"
+        app:maplibre_uiTiltGestures="true"
+        app:maplibre_uiZoomGestures="true" />
+
+    <Button
+        android:id="@+id/btnStartNavigation"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginBottom="8dp"
+        android:text="Start"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_snap_to_route_navigation.xml
+++ b/app/src/main/res/layout/activity_snap_to_route_navigation.xml
@@ -34,13 +34,13 @@
         app:maplibre_uiZoomGestures="true" />
 
     <Button
-        android:id="@+id/btnStartNavigation"
+        android:id="@+id/btnFollow"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
         android:layout_marginEnd="8dp"
         android:layout_marginBottom="8dp"
-        android:text="Start"
+        android:text="Follow"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,9 @@
     <string name="title_navigation_ui">Navigation UI</string>
     <string name="description_navigation_ui">Showcase a Navigation UI session. Optional with simulation.</string>
 
+    <string name="title_snap_to_route">Snap to route</string>
+    <string name="description_snap_to_route">Use snap to route option to show smoother location updates.</string>
+
     <string name="title_off_route_detection">Off route detection</string>
     <string name="description_off_route_detection">Uses the Route Utils class to determine if a users off route.</string>
 


### PR DESCRIPTION
This PR will add some basic route snapping example. It's very simple. The route is fixed and navigation starts automatically.

I need this example as a show case for a bug in the default route snap engine. This is the reason that I will split the markdown documentation and example implementation in two PRs.