### PR TITLE
Skip calculating step distance when too far away from the step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Maplibre welcomes participation and contributions from everyone.
 
-### v2.0.1 - unreleased
+### v2.1.0 - unreleased
 
 - Sample app: Moved all configurations to a central place [#57](https://github.com/maplibre/maplibre-navigation-android/pull/57)
   > **Note**  
@@ -21,6 +21,7 @@ Maplibre welcomes participation and contributions from everyone.
   </resources>
   ```
 - Fix memory leak in Navigation Service
+- Only progress the user along the step / route if the user is close to the route (currently 1km), [#75](https://github.com/maplibre/maplibre-navigation-android/pull/75)
 
 ### v2.0.0 - March 21, 2023
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelper.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelper.java
@@ -37,6 +37,8 @@ import java.util.List;
 
 import static com.mapbox.core.constants.Constants.PRECISION_6;
 
+import timber.log.Timber;
+
 /**
  * This contains several single purpose methods that help out when a new location update occurs and
  * calculations need to be performed on it.
@@ -53,24 +55,6 @@ public class NavigationHelper {
 
   private NavigationHelper() {
     // Empty private constructor to prevent users creating an instance of this class.
-  }
-
-  /**
-   * Takes in a raw location, converts it to a point, and snaps it to the closest point along the
-   * route. This is isolated as separate logic from the snap logic provided because we will always
-   * need to snap to the route in order to get the most accurate information.
-   */
-  static Point userSnappedToRoutePosition(Location location, List<Point> coordinates) {
-    if (coordinates.size() < 2) {
-      return Point.fromLngLat(location.getLongitude(), location.getLatitude());
-    }
-
-    Point locationToPoint = Point.fromLngLat(location.getLongitude(), location.getLatitude());
-
-    // Uses Turf's pointOnLine, which takes a Point and a LineString to calculate the closest
-    // Point on the LineString.
-    Feature feature = TurfMisc.nearestPointOnLine(locationToPoint, coordinates);
-    return ((Point) feature.geometry());
   }
 
   static Location buildSnappedLocation(MapboxNavigation mapboxNavigation, boolean snapToRouteEnabled,
@@ -100,24 +84,42 @@ public class NavigationHelper {
    * Calculates the distance remaining in the step from the current users snapped position, to the
    * next maneuver position.
    */
-  static double stepDistanceRemaining(Point snappedPosition, int legIndex, int stepIndex,
-                                      DirectionsRoute directionsRoute, List<Point> coordinates) {
+  static double stepDistanceRemaining(Location location, int legIndex, int stepIndex,
+                                      DirectionsRoute directionsRoute, List<Point> stepPoints) {
+    // If the linestring coordinate size is less than 2,the distance remaining is zero.
+    if (stepPoints.size() < 2) {
+      return 0;
+    }
+
+    Point locationToPoint = Point.fromLngLat(location.getLongitude(), location.getLatitude());
+
+    // Uses Turf's pointOnLine, which takes a Point and a LineString to calculate the closest
+    // Point on the LineString.
+    Feature feature = TurfMisc.nearestPointOnLine(locationToPoint, stepPoints, TurfConstants.UNIT_KILOMETERS);
+
+    // Check distance to route line, if it's too high, it makes no sense to snap and we assume the step distance is the whole distance of the step
+    Number distance = feature.getNumberProperty("dist");
+    if(distance != null && distance.doubleValue() > 1){
+      Timber.i("Distance to step is larger than 1km, so we won't advance the step, distance: %s km",distance.doubleValue());
+      return TurfMeasurement.length(stepPoints, TurfConstants.UNIT_METERS);
+    }
+
+    Point snappedPosition = ((Point) feature.geometry());
+
     List<LegStep> steps = directionsRoute.legs().get(legIndex).steps();
-    Point nextManeuverPosition = nextManeuverPosition(stepIndex, steps, coordinates);
+    Point nextManeuverPosition = nextManeuverPosition(stepIndex, steps, stepPoints);
 
     // When the coordinates are empty, no distance can be calculated
     if(nextManeuverPosition == null) {
       return 0;
     }
 
-    LineString lineString = LineString.fromPolyline(steps.get(stepIndex).geometry(),
-      Constants.PRECISION_6);
-    // If the users snapped position equals the next maneuver
-    // position or the linestring coordinate size is less than 2,the distance remaining is zero.
-    if (snappedPosition.equals(nextManeuverPosition) || lineString.coordinates().size() < 2) {
+    // If the users snapped position equals the next maneuver position
+    if (snappedPosition.equals(nextManeuverPosition)) {
       return 0;
     }
-    LineString slicedLine = TurfMisc.lineSlice(snappedPosition, nextManeuverPosition, lineString);
+
+    LineString slicedLine = TurfMisc.lineSlice(snappedPosition, nextManeuverPosition, LineString.fromLngLats(stepPoints));
     return TurfMeasurement.length(slicedLine, TurfConstants.UNIT_METERS);
   }
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelper.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelper.java
@@ -13,7 +13,6 @@ import com.mapbox.api.directions.v5.models.MaxSpeed;
 import com.mapbox.api.directions.v5.models.RouteLeg;
 import com.mapbox.api.directions.v5.models.StepIntersection;
 import com.mapbox.api.directions.v5.models.StepManeuver;
-import com.mapbox.core.constants.Constants;
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.Point;
@@ -83,6 +82,8 @@ public class NavigationHelper {
   /**
    * Calculates the distance remaining in the step from the current users snapped position, to the
    * next maneuver position.
+   *
+   * If the user is more than 1km away from the route, we are returning the total step distance.
    */
   static double stepDistanceRemaining(Location location, int legIndex, int stepIndex,
                                       DirectionsRoute directionsRoute, List<Point> stepPoints) {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessor.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessor.java
@@ -28,7 +28,6 @@ import static com.mapbox.services.android.navigation.v5.navigation.NavigationHel
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.legDistanceRemaining;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.routeDistanceRemaining;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.stepDistanceRemaining;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.userSnappedToRoutePosition;
 
 class NavigationRouteProcessor implements OffRouteCallback {
 
@@ -135,9 +134,8 @@ class NavigationRouteProcessor implements OffRouteCallback {
    * @return distance remaining in meters
    */
   private double calculateStepDistanceRemaining(Location location, DirectionsRoute directionsRoute) {
-    Point snappedPosition = userSnappedToRoutePosition(location, currentStepPoints);
     return stepDistanceRemaining(
-      snappedPosition, indices.legIndex(), indices.stepIndex(), directionsRoute, currentStepPoints
+      location, indices.legIndex(), indices.stepIndex(), directionsRoute, currentStepPoints
     );
   }
 

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelperTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelperTest.java
@@ -130,14 +130,27 @@ public class NavigationHelperTest extends BaseTest {
     @Test
     public void stepDistanceRemaining_returnsZeroWhenPositionsEqualEachOther() throws Exception {
         DirectionsRoute route = buildMultiLegRoute();
-        Point snappedPoint = Point.fromLngLat(-77.062996, 38.798405);
+        Location location = buildDefaultLocationUpdate(-77.062996, 38.798405);
         List<Point> coordinates = PolylineUtils.decode(
                 route.legs().get(0).steps().get(1).geometry(), Constants.PRECISION_6
         );
 
-        double distance = NavigationHelper.stepDistanceRemaining(snappedPoint, 0, 1, route, coordinates);
+        double distance = NavigationHelper.stepDistanceRemaining(location, 0, 1, route, coordinates);
 
         assertEquals(0.0, distance);
+    }
+
+    @Test
+    public void stepDistanceRemaining_returnsFullLengthForLargeDistance() throws Exception {
+        DirectionsRoute route = buildMultiLegRoute();
+        Location location = buildDefaultLocationUpdate(0, 0);
+        List<Point> coordinates = PolylineUtils.decode(
+                route.legs().get(0).steps().get(1).geometry(), Constants.PRECISION_6
+        );
+
+        double distance = NavigationHelper.stepDistanceRemaining(location, 0, 1, route, coordinates);
+
+        assertEquals(25.0, distance, 1);
     }
 
     @Test


### PR DESCRIPTION
This PR improves progress updates if the user is too far from the route. If the user is further away then 1km from the route, we don't progress along the step anymore.

Before this was done, independent of how far the user is away from the route.

This change should only be relevant if you have a fixed route, if you reroute, once the user if offroute, this should not be a relevant change.