### PR TITLE
Add foregroundServiceType for forwardsCompatibility

### DIFF
--- a/libandroid-navigation/src/main/AndroidManifest.xml
+++ b/libandroid-navigation/src/main/AndroidManifest.xml
@@ -6,7 +6,9 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application>
-        <service android:name="com.mapbox.services.android.navigation.v5.navigation.NavigationService" />
+        <service
+            android:name="com.mapbox.services.android.navigation.v5.navigation.NavigationService"
+            android:foregroundServiceType="location" />
         <provider
             android:name="com.mapbox.android.telemetry.provider.MapboxTelemetryInitProvider"
             android:authorities="${applicationId}.mapboxtelemetryinitprovider"


### PR DESCRIPTION
From Android 14 on, the foregroundServiceType is mandatory and depending on the maplibre sdk will crash the build if this is not included. The type was introduced with Android 10, but ist backwards compatible as old versions simply ignore unknown fields in the manifest