### PR TITLE
Fix rerouting not take effect on off route event.

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/RouteFetcher.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/RouteFetcher.java
@@ -80,7 +80,7 @@ public class RouteFetcher {
   @Nullable
   public NavigationRoute.Builder buildRequest(Location location, RouteProgress progress) {
     Context context = contextWeakReference.get();
-    if (invalid(context, location, routeProgress)) {
+    if (invalid(context, location, progress)) {
       return null;
     }
     Point origin = Point.fromLngLat(location.getLongitude(), location.getLatitude());


### PR DESCRIPTION
Think the progress variable here should be the method parameter `routeProgress` rather than class member variable `this.routeProgress`. When buildRequest() is called by findRouteFromRouteProgress(), this.routeProgress = routeProgress. However when it is called by findRouteFrom(), this.routeProgress is not assigned. So when rerouting occurs on off route event, it doesn't take effect.