### PR TITLE
Make some navigation classes and methods public for extended usability

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewRouter.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewRouter.java
@@ -16,7 +16,7 @@ import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import java.util.Date;
 import java.util.List;
 
-class NavigationViewRouter implements RouteListener {
+public class NavigationViewRouter implements RouteListener {
 
   private final MapboxRouteFetcher onlineRouter;
   private final ConnectivityStatusProvider connectivityStatus;
@@ -28,8 +28,8 @@ class NavigationViewRouter implements RouteListener {
   private Location location;
   private RouteCallStatus callStatus;
 
-  NavigationViewRouter(MapboxRouteFetcher onlineRouter, ConnectivityStatusProvider connectivityStatus,
-                       ViewRouteListener listener) {
+  public NavigationViewRouter(MapboxRouteFetcher onlineRouter, ConnectivityStatusProvider connectivityStatus,
+                              ViewRouteListener listener) {
     this.onlineRouter = onlineRouter;
     this.connectivityStatus = connectivityStatus;
     this.listener = listener;
@@ -67,7 +67,7 @@ class NavigationViewRouter implements RouteListener {
     extractRouteFrom(options);
   }
 
-  void findRouteFrom(@Nullable RouteProgress routeProgress) {
+  public void findRouteFrom(@Nullable RouteProgress routeProgress) {
     if (isRouting()) {
       return;
     }
@@ -75,11 +75,11 @@ class NavigationViewRouter implements RouteListener {
     findOnlineRouteWith(builder);
   }
 
-  void updateLocation(@NonNull Location location) {
+  public void updateLocation(@NonNull Location location) {
     this.location = location;
   }
 
-  void updateCurrentRoute(DirectionsRoute currentRoute) {
+  public void updateCurrentRoute(DirectionsRoute currentRoute) {
     this.currentRoute = currentRoute;
     listener.onRouteUpdate(currentRoute);
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewRouter.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewRouter.java
@@ -79,7 +79,7 @@ public class NavigationViewRouter implements RouteListener {
     this.location = location;
   }
 
-  public void updateCurrentRoute(DirectionsRoute currentRoute) {
+  void updateCurrentRoute(DirectionsRoute currentRoute) {
     this.currentRoute = currentRoute;
     listener.onRouteUpdate(currentRoute);
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/ViewRouteListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/ViewRouteListener.java
@@ -3,7 +3,7 @@ package com.mapbox.services.android.navigation.ui.v5;
 import com.mapbox.services.android.navigation.v5.models.DirectionsRoute;
 import com.mapbox.geojson.Point;
 
-interface ViewRouteListener {
+public interface ViewRouteListener {
 
   void onRouteUpdate(DirectionsRoute directionsRoute);
 


### PR DESCRIPTION
This PR updates the access modifiers of `ViewRouteListener` and `NavigationViewRouter`, along with three of its methods (`findRouteFrom`, `updateLocation`), to public. These changes are essential to allow developers to handle rerouting more directly within their applications. Without these modifications, developers are forced to rely on less desirable solutions such as duplicating internal code or employing fragile workarounds. Making these classes and methods public simplifies the development process and enhances the flexibility of the navigation functionality.

I welcome feedback on these changes and am open to discussing alternative approaches. Please share any suggestions or insights you have.

Several useful classes in the library are internal, limiting their direct usability. I’d appreciate insights into the decision for such accessibility settings to align our development efforts better.
