### PR TITLE
Making TurnLaneViewData Public

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/turnlane/TurnLaneViewData.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/turnlane/TurnLaneViewData.java
@@ -9,7 +9,7 @@ import static com.mapbox.services.android.navigation.v5.navigation.NavigationCon
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.TURN_LANE_INDICATION_STRAIGHT;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.TURN_LANE_INDICATION_UTURN;
 
-class TurnLaneViewData {
+public class TurnLaneViewData {
 
   static final String DRAW_LANE_SLIGHT_RIGHT = "draw_lane_slight_right";
   static final String DRAW_LANE_RIGHT = "draw_lane_right";
@@ -29,7 +29,7 @@ class TurnLaneViewData {
     return shouldFlip;
   }
 
-  String getDrawMethod() {
+  public String getDrawMethod() {
     return drawMethod;
   }
 


### PR DESCRIPTION
We would like to develop a Custom Lane Guidance with a customized design, and we require the `TurnLaneViewData` to achieve this. As a result, we are proposing to make it accessible through the public API and would like to understand why it is currently hidden.