### PR TITLE
Fix leaking MapView due to annotations plugin

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -705,6 +705,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleOwner,
   private void shutdown() {
     if (navigationMap != null) {
       navigationMap.removeOnCameraTrackingChangedListener(onTrackingChangedListener);
+      navigationMap.onDestroy();
     }
     navigationViewEventDispatcher.onDestroy(navigationViewModel.retrieveNavigation());
     mapView.onDestroy();

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMap.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMap.java
@@ -1,5 +1,8 @@
 package com.mapbox.services.android.navigation.ui.v5.map;
 
+import static com.mapbox.services.android.navigation.ui.v5.map.NavigationSymbolManager.MAPBOX_NAVIGATION_MARKER_NAME;
+import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.NAVIGATION_MINIMUM_MAP_ZOOM;
+
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Bitmap;
@@ -7,12 +10,12 @@ import android.graphics.PointF;
 import android.location.Location;
 import android.os.Bundle;
 import android.os.PersistableBundle;
+
 import androidx.annotation.AnyRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
 
-import com.mapbox.services.android.navigation.v5.models.DirectionsRoute;
 import com.mapbox.geojson.Point;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.location.LocationComponent;
@@ -33,13 +36,11 @@ import com.mapbox.services.android.navigation.ui.v5.ThemeSwitcher;
 import com.mapbox.services.android.navigation.ui.v5.camera.NavigationCamera;
 import com.mapbox.services.android.navigation.ui.v5.route.NavigationMapRoute;
 import com.mapbox.services.android.navigation.ui.v5.route.OnRouteSelectionChangeListener;
+import com.mapbox.services.android.navigation.v5.models.DirectionsRoute;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-
-import static com.mapbox.services.android.navigation.ui.v5.map.NavigationSymbolManager.MAPBOX_NAVIGATION_MARKER_NAME;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.NAVIGATION_MINIMUM_MAP_ZOOM;
 
 /**
  * Wrapper class for {@link MapboxMap}.
@@ -480,6 +481,16 @@ public class NavigationMapboxMap {
     handleFpsOnStop();
     locationFpsDelegate.onStop();
   }
+
+    /**
+     * Should be used in {@link FragmentActivity#onDestroy()} to ensure proper
+     * accounting for the lifecycle.
+     */
+    public void onDestroy() {
+      if (navigationSymbolManager != null) {
+        navigationSymbolManager.onDestroy();
+      }
+    }
 
   /**
    * Hide or show the location icon on the map.

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationSymbolManager.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationSymbolManager.java
@@ -1,6 +1,7 @@
 package com.mapbox.services.android.navigation.ui.v5.map;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.UiThread;
 
 import com.mapbox.geojson.Point;
 import com.mapbox.mapboxsdk.geometry.LatLng;
@@ -51,5 +52,10 @@ class NavigationSymbolManager {
   private void createSymbolFrom(SymbolOptions options) {
     Symbol symbol = symbolManager.create(options);
     mapMarkersSymbols.add(symbol);
+  }
+
+  @UiThread
+  public void onDestroy() {
+    symbolManager.onDestroy();
   }
 }


### PR DESCRIPTION
When using SymbolManager (part of the annotations plugin), a strong reference is kept to the MapView until it is explicitly cleared. This patch adds methods to allow calling AnnotationManager's onDestroy to explicitly clear the MapView reference.