### PR TITLE
Fix NullPointerException in ManeuverView

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/maneuver/ManeuverView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/maneuver/ManeuverView.java
@@ -240,7 +240,7 @@ public class ManeuverView extends View {
         if (ROUNDABOUT_MANEUVER_TYPES.contains(maneuverType)) {
             flip = STEP_MANEUVER_MODIFIER_LEFT.equals(drivingSide);
         }
-        if (STEP_MANEUVER_MODIFIER_LEFT.equals(drivingSide) && STEP_MANEUVER_MODIFIER_UTURN.contains(maneuverModifier)) {
+        if (STEP_MANEUVER_MODIFIER_LEFT.equals(drivingSide) && STEP_MANEUVER_MODIFIER_UTURN.equals(maneuverModifier)) {
             setScaleX(flip ? 1 : -1);
         } else {
             setScaleX(flip ? -1 : 1);


### PR DESCRIPTION
closes #122 

As outlined in #122 this PR should fix the `NullPointerException` being thrown in `ManeuverView`.