### PR TITLE
Change delay type to Long

### DIFF
--- a/libandroid-navigation/src/main/java/org/maplibre/navigation/android/navigation/v5/location/replay/ReplayRouteLocationConverter.kt
+++ b/libandroid-navigation/src/main/java/org/maplibre/navigation/android/navigation/v5/location/replay/ReplayRouteLocationConverter.kt
@@ -11,7 +11,7 @@ import org.maplibre.turf.TurfMeasurement
 open class ReplayRouteLocationConverter(
     private val route: DirectionsRoute,
     private var speed: Int,
-    private var delay: Int
+    private var delay: Long
 ) {
     private var distance = calculateDistancePerSec()
     private var currentLeg = 0
@@ -27,7 +27,11 @@ open class ReplayRouteLocationConverter(
     }
 
     fun updateDelay(customDelayInSeconds: Int) {
-        this.delay = customDelayInSeconds
+        this.delay = customDelayInSeconds * ONE_SECOND_IN_MILLISECONDS
+    }
+
+    fun updateDelayMs(customDelayInMilliseconds: Long) {
+        this.delay = customDelayInMilliseconds
     }
 
     fun toLocations(): MutableList<Location> {
@@ -78,7 +82,7 @@ open class ReplayRouteLocationConverter(
             } else {
                 mockedLocation.bearing = 0f
             }
-            time += (delay * ONE_SECOND_IN_MILLISECONDS).toLong()
+            time += delay
             mockedLocations.add(mockedLocation)
         }
 
@@ -91,7 +95,7 @@ open class ReplayRouteLocationConverter(
      * @return a double value representing the distance given a speed and time.
      */
     private fun calculateDistancePerSec(): Double {
-        val distance = (speed * ONE_KM_IN_METERS * delay) / ONE_HOUR_IN_SECONDS
+        val distance = (speed * ONE_KM_IN_METERS * delay) / (ONE_HOUR_IN_SECONDS * ONE_SECOND_IN_MILLISECONDS)
         return distance
     }
 
@@ -126,7 +130,7 @@ open class ReplayRouteLocationConverter(
     }
 
     companion object {
-        private const val ONE_SECOND_IN_MILLISECONDS = 1000
+        private const val ONE_SECOND_IN_MILLISECONDS = 1000L
         private const val ONE_KM_IN_METERS = 1000.0
         private const val ONE_HOUR_IN_SECONDS = 3600
         private const val REPLAY_ROUTE = "ReplayRouteLocation"

--- a/libandroid-navigation/src/main/java/org/maplibre/navigation/android/navigation/v5/location/replay/ReplayRouteLocationEngine.kt
+++ b/libandroid-navigation/src/main/java/org/maplibre/navigation/android/navigation/v5/location/replay/ReplayRouteLocationEngine.kt
@@ -58,7 +58,12 @@ open class ReplayRouteLocationEngine : LocationEngine, Runnable {
 
     fun updateDelay(customDelayInSeconds: Int) {
         require(customDelayInSeconds > 0) { DELAY_MUST_BE_GREATER_THAN_ZERO_SECONDS }
-        this.delay = customDelayInSeconds
+        this.delay = customDelayInSeconds * ONE_SECOND_IN_MILLISECONDS
+    }
+
+    fun updateDelayMs(customDelayInMilliseconds: Long) {
+        require(customDelayInMilliseconds > 0) { DELAY_MUST_BE_GREATER_THAN_ZERO_MILLISECONDS }
+        this.delay = customDelayInMilliseconds
     }
 
     override fun run() {
@@ -106,7 +111,7 @@ open class ReplayRouteLocationEngine : LocationEngine, Runnable {
         converter?.let { converter ->
             handler.removeCallbacks(this)
             converter.updateSpeed(speed)
-            converter.updateDelay(delay)
+            converter.updateDelayMs(delay)
             converter.initializeTime()
 
             val route = obtainRoute(point, lastLocation)
@@ -128,11 +133,11 @@ open class ReplayRouteLocationEngine : LocationEngine, Runnable {
         if (currentMockedPoints == ZERO) {
             handler.postDelayed(this, DO_NOT_DELAY.toLong())
         } else if (currentMockedPoints <= MOCKED_POINTS_LEFT_THRESHOLD) {
-            handler.postDelayed(this, ONE_SECOND_IN_MILLISECONDS.toLong())
+            handler.postDelayed(this, delay)
         } else {
             handler.postDelayed(
                 this,
-                ((currentMockedPoints - MOCKED_POINTS_LEFT_THRESHOLD) * ONE_SECOND_IN_MILLISECONDS).toLong()
+                ((currentMockedPoints - MOCKED_POINTS_LEFT_THRESHOLD) * delay)
             )
         }
     }
@@ -182,17 +187,18 @@ open class ReplayRouteLocationEngine : LocationEngine, Runnable {
 
     companion object {
         private const val MOCKED_POINTS_LEFT_THRESHOLD = 5
-        private const val ONE_SECOND_IN_MILLISECONDS = 1000
+        private const val ONE_SECOND_IN_MILLISECONDS = 1000L
         private const val FORTY_FIVE_KM_PER_HOUR = 45
         private const val DEFAULT_SPEED = FORTY_FIVE_KM_PER_HOUR
-        private const val ONE_SECOND = 1
-        private const val DEFAULT_DELAY = ONE_SECOND
+        private const val DEFAULT_DELAY = ONE_SECOND_IN_MILLISECONDS
         private const val DO_NOT_DELAY = 0
         private const val ZERO = 0
         private const val SPEED_MUST_BE_GREATER_THAN_ZERO_KM_H =
             "Speed must be greater than 0 km/h."
         private const val DELAY_MUST_BE_GREATER_THAN_ZERO_SECONDS =
             "Delay must be greater than 0 seconds."
+        private const val DELAY_MUST_BE_GREATER_THAN_ZERO_MILLISECONDS =
+            "Delay must be greater than 0 milliseconds."
         private const val REPLAY_ROUTE = "ReplayRouteLocation"
     }
 }


### PR DESCRIPTION
This pull should fix the problem pointed out by @javaherisaber in #108 

I changed the delay variable from seconds to milliseconds to reduce the gap between the real location and the puck. 
The default value is still 1 second but it is possible to update it with `locationEngine.updateDelayMs(...)`.
The old function `locationEngine.updateDelay(...)` wasn't deleted because of retrocompatibility.

In the first video you can see the problem and in the second video you can see it fixed with a delay of 250 milliseconds. The marker is the real location.

https://github.com/user-attachments/assets/f6cfb041-3972-47c8-8e8e-43c20668959d

https://github.com/user-attachments/assets/c473abdb-4d3a-4d92-81b3-679305d6f92e


