### PR TITLE
Fix nullability-related crashes after Java -> Kotlin migration

### DIFF
--- a/libandroid-navigation/src/main/java/org/maplibre/navigation/android/navigation/v5/location/engine/GoogleLocationEngineImpl.kt
+++ b/libandroid-navigation/src/main/java/org/maplibre/navigation/android/navigation/v5/location/engine/GoogleLocationEngineImpl.kt
@@ -68,10 +68,7 @@ open class GoogleLocationEngineImpl(
         )
     }
 
-    override fun removeLocationUpdates(listener: LocationCallback) {
-        // The listener is annotated with @NonNull, but there seems to be cases where a null
-        // listener is somehow passed into this method.
-        @Suppress("SENSELESS_COMPARISON")
+    override fun removeLocationUpdates(listener: LocationCallback?) {
         if (listener != null) {
             fusedLocationProviderClient.removeLocationUpdates(listener)
         }

--- a/libandroid-navigation/src/main/java/org/maplibre/navigation/android/navigation/v5/navigation/NavigationService.kt
+++ b/libandroid-navigation/src/main/java/org/maplibre/navigation/android/navigation/v5/navigation/NavigationService.kt
@@ -41,7 +41,7 @@ open class NavigationService : Service() {
      * Only should be called once since we want the service to continue running until the navigation
      * session ends.
      */
-    override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         return START_STICKY
     }
 


### PR DESCRIPTION
We've observed two crashes related to Java passing `null` as parameter values and Kotlin expecting a non-nullable type.
Both of those has been addressed here by making the Kotlin type nullable.