### PR TITLE
Add placeholder build script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: "Test, build and release"
+env:
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        type: boolean
+        default: false
+        description: Whether to make a release
+  pull_request:
+  push:
+    paths-ignore:
+      - "README.md"
+      - ".gitignore"
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Placeholder
+        run: echo "Hello world!!11!!1"


### PR DESCRIPTION
Placeholder script, to allow triggering `build.yaml` manually.

> To trigger the workflow_dispatch event, your workflow must be in the **default branch**. For more information about configuring the workflow_dispatch event, see [Events that trigger workflows](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch).

From: https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow