### PR TITLE
avoid npe when modifier is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ MapLibre welcomes participation and contributions from everyone.
 
 ### unreleased
 
+- Fix crash on MapFpsDelegate, caused by null modifier [#141](https://github.com/maplibre/maplibre-navigation-android/issues/141)
+
 ### v5.0.0-pre5 - May 16, 2025
 
 - Fix threading and platform characteristics for Apple location engine [#159](https://github.com/maplibre/maplibre-navigation-android/pull/159)

--- a/libandroid-navigation-ui/src/main/java/org/maplibre/navigation/android/navigation/ui/v5/map/MapFpsDelegate.java
+++ b/libandroid-navigation-ui/src/main/java/org/maplibre/navigation/android/navigation/ui/v5/map/MapFpsDelegate.java
@@ -6,6 +6,7 @@ import org.maplibre.android.maps.MapView;
 import org.maplibre.navigation.android.navigation.ui.v5.camera.NavigationCamera;
 import org.maplibre.navigation.android.navigation.ui.v5.camera.OnTrackingModeChangedListener;
 import org.maplibre.navigation.android.navigation.ui.v5.camera.OnTrackingModeTransitionListener;
+import org.maplibre.navigation.core.models.ManeuverModifier;
 import org.maplibre.navigation.core.navigation.MapLibreNavigation;
 import org.maplibre.navigation.core.navigation.NavigationConstants;
 import org.maplibre.navigation.core.routeprogress.ProgressChangeListener;
@@ -111,7 +112,12 @@ class MapFpsDelegate implements OnTrackingModeChangedListener, OnTrackingModeTra
   }
 
   private boolean validLowFpsManeuver(RouteLegProgress routeLegProgress) {
-    final String maneuverModifier = routeLegProgress.getCurrentStep().getManeuver().getModifier().getText();
+    ManeuverModifier.Type modifier = routeLegProgress.getCurrentStep().getManeuver().getModifier();
+    if (modifier == null) {
+      return false;
+    }
+
+    final String maneuverModifier = modifier.getText();
     return maneuverModifier != null
       && (maneuverModifier.equals(NavigationConstants.STEP_MANEUVER_MODIFIER_STRAIGHT)
       || maneuverModifier.equals(NavigationConstants.STEP_MANEUVER_MODIFIER_SLIGHT_LEFT)

--- a/libandroid-navigation-ui/src/test/java/org/maplibre/navigation/android/navigation/ui/v5/map/MapFpsDelegateTest.java
+++ b/libandroid-navigation-ui/src/test/java/org/maplibre/navigation/android/navigation/ui/v5/map/MapFpsDelegateTest.java
@@ -103,6 +103,34 @@ public class MapFpsDelegateTest {
     verify(mapView).setMaximumFps(eq(maxFps));
   }
 
+  @Test
+  public void adjustFpsFor_nullModifier_thresholdSetWithNullModifier() {
+    MapView mapView = mock(MapView.class);
+    MapBatteryMonitor batteryMonitor = mock(MapBatteryMonitor.class);
+    when(batteryMonitor.isPluggedIn(any(Context.class))).thenReturn(false);
+    MapFpsDelegate delegate = new MapFpsDelegate(mapView, batteryMonitor);
+
+    // Build a RouteProgress whose current step's maneuver has a null modifier
+    RouteProgress routeProgress = mock(RouteProgress.class);
+    RouteLegProgress routeLegProgress = mock(RouteLegProgress.class);
+    RouteStepProgress routeStepProgress = mock(RouteStepProgress.class);
+    StepManeuver currentManeuver = mock(StepManeuver.class);
+    when(currentManeuver.getModifier()).thenReturn(null);
+    LegStep currentStep = mock(LegStep.class);
+    when(currentStep.getDuration()).thenReturn(100d);
+    when(routeStepProgress.getDurationRemaining()).thenReturn(20d);
+    when(routeLegProgress.getCurrentStepProgress()).thenReturn(routeStepProgress);
+    when(routeProgress.getCurrentLegProgress()).thenReturn(routeLegProgress);
+    when(currentStep.getManeuver()).thenReturn(currentManeuver);
+    when(routeLegProgress.getCurrentStep()).thenReturn(currentStep);
+
+    int maxFps = 5;
+    delegate.updateMaxFpsThreshold(maxFps);
+    delegate.adjustFpsFor(routeProgress);
+
+    verify(mapView).setMaximumFps(eq(maxFps)) ;
+  }
+
   private RouteProgress buildRouteProgressWith(ManeuverModifier.Type maneuverModifier) {
     RouteProgress routeProgress = mock(RouteProgress.class);
     RouteLegProgress routeLegProgress = mock(RouteLegProgress.class);


### PR DESCRIPTION
Closes #141 

As outlined in https://github.com/maplibre/maplibre-navigation-android/issues/141 this PR should fix the `NullPointerException` being thrown in `MapFpsDelegate`.