### PR TITLE
added graphhopper sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ MapLibre welcomes participation and contributions from everyone.
 
 ### unreleased
 
+Added sample code on how to use the GraphHopper routing server directly in GraphHopperNavigationActivity. Please make sure to add this line to the app/main/res/values/developer-config.xml:
+
+```xml
+  <string name="graphhopper_url" translatable="false">https://graphhopper.com/api/1/navigate?key=YOUR_API_KEY</string>
+```
+
 ### v5.0.0-pre5 - May 16, 2025
 
 - Fix threading and platform characteristics for Apple location engine [#159](https://github.com/maplibre/maplibre-navigation-android/pull/159)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,13 @@
                 android:value=".MainActivity" />
         </activity>
         <activity
+            android:name=".GraphHopperNavigationActivity"
+            android:label="@string/title_graphhopper_navigation">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".MainActivity" />
+        </activity>
+        <activity
             android:name=".NavigationUIActivity"
             android:label="@string/title_navigation_ui">
             <meta-data

--- a/app/src/main/java/org/maplibre/navigation/android/example/GraphHopperNavigationActivity.kt
+++ b/app/src/main/java/org/maplibre/navigation/android/example/GraphHopperNavigationActivity.kt
@@ -1,0 +1,284 @@
+package org.maplibre.navigation.android.example
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.snackbar.Snackbar
+import com.google.gson.Gson
+import org.maplibre.geojson.model.Point
+import org.maplibre.android.annotations.MarkerOptions
+import org.maplibre.android.camera.CameraPosition
+import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.location.LocationComponent
+import org.maplibre.android.location.LocationComponentActivationOptions
+import org.maplibre.android.location.modes.CameraMode
+import org.maplibre.android.location.modes.RenderMode
+import org.maplibre.android.maps.MapLibreMap
+import org.maplibre.android.maps.OnMapReadyCallback
+import org.maplibre.android.maps.Style
+import org.maplibre.navigation.android.example.databinding.ActivityNavigationUiBinding
+import org.maplibre.navigation.android.navigation.ui.v5.NavigationLauncher
+import org.maplibre.navigation.android.navigation.ui.v5.NavigationLauncherOptions
+import org.maplibre.navigation.core.models.DirectionsResponse
+import org.maplibre.navigation.core.models.DirectionsRoute
+import org.maplibre.navigation.core.models.RouteOptions
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.maplibre.geojson.turf.TurfUnit
+import org.maplibre.navigation.android.navigation.ui.v5.route.NavigationMapRoute
+import timber.log.Timber
+import java.io.IOException
+import java.util.Locale
+
+class GraphHopperNavigationActivity :
+    AppCompatActivity(),
+    OnMapReadyCallback,
+    MapLibreMap.OnMapClickListener {
+    private lateinit var mapLibreMap: MapLibreMap
+
+    // Navigation related variables
+    private var language = Locale.getDefault().language
+    private var route: DirectionsRoute? = null
+    private var navigationMapRoute: NavigationMapRoute? = null
+    private var destination: Point? = null
+    private var locationComponent: LocationComponent? = null
+
+    private lateinit var binding: ActivityNavigationUiBinding
+
+    private var simulateRoute = false
+
+    @SuppressLint("MissingPermission")
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        if (BuildConfig.DEBUG) {
+            Timber.plant(Timber.DebugTree())
+        }
+
+        binding = ActivityNavigationUiBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        binding.mapView.apply {
+            onCreate(savedInstanceState)
+            getMapAsync(this@GraphHopperNavigationActivity)
+        }
+
+        binding.startRouteButton.setOnClickListener {
+            route?.let { route ->
+                val userLocation = mapLibreMap.locationComponent.lastKnownLocation ?: return@let
+                val options = NavigationLauncherOptions.builder()
+                    .directionsRoute(route)
+                    .shouldSimulateRoute(simulateRoute)
+                    .initialMapCameraPosition(
+                        CameraPosition.Builder()
+                            .target(LatLng(userLocation.latitude, userLocation.longitude)).build()
+                    )
+                    .lightThemeResId(R.style.TestNavigationViewLight)
+                    .darkThemeResId(R.style.TestNavigationViewDark)
+                    .build()
+                NavigationLauncher.startNavigation(this@GraphHopperNavigationActivity, options)
+            }
+        }
+
+        binding.simulateRouteSwitch.setOnCheckedChangeListener { _, checked ->
+            simulateRoute = checked
+        }
+
+        binding.clearPoints.setOnClickListener {
+            if (::mapLibreMap.isInitialized) {
+                mapLibreMap.markers.forEach {
+                    mapLibreMap.removeMarker(it)
+                }
+            }
+            destination = null
+            it.visibility = View.GONE
+            binding.startRouteLayout.visibility = View.GONE
+
+            navigationMapRoute?.removeRoute()
+        }
+    }
+
+    override fun onMapReady(mapLibreMap: MapLibreMap) {
+        this.mapLibreMap = mapLibreMap
+        mapLibreMap.setStyle(
+            Style.Builder().fromUri(getString(R.string.map_style_light))
+        ) { style ->
+            enableLocationComponent(style)
+            navigationMapRoute = NavigationMapRoute(binding.mapView, mapLibreMap)
+            mapLibreMap.addOnMapClickListener(this)
+
+            Snackbar.make(
+                findViewById(R.id.container),
+                "Tap map to place destination",
+                Snackbar.LENGTH_LONG,
+            ).show()
+        }
+    }
+
+    @SuppressWarnings("MissingPermission")
+    private fun enableLocationComponent(style: Style) {
+        // Get an instance of the component
+        locationComponent = mapLibreMap.locationComponent
+
+        locationComponent?.let {
+            // Activate with a built LocationComponentActivationOptions object
+            it.activateLocationComponent(
+                LocationComponentActivationOptions.builder(this, style).build(),
+            )
+
+            // Enable to make component visible
+            it.isLocationComponentEnabled = true
+
+            // Set the component's camera mode
+            it.cameraMode = CameraMode.TRACKING_GPS_NORTH
+
+            // Set the component's render mode
+            it.renderMode = RenderMode.NORMAL
+        }
+    }
+
+    override fun onMapClick(point: LatLng): Boolean {
+        destination = Point(point.longitude, point.latitude)
+
+        mapLibreMap.addMarker(MarkerOptions().position(point))
+        binding.clearPoints.visibility = View.VISIBLE
+        calculateRoute()
+        return true
+    }
+
+    private fun calculateRoute() {
+        binding.startRouteLayout.visibility = View.GONE
+        val userLocation = mapLibreMap.locationComponent.lastKnownLocation
+        val destination = destination
+        if (userLocation == null) {
+            Timber.d("calculateRoute: User location is null, therefore, origin can't be set.")
+            return
+        }
+
+        if (destination == null) {
+            Timber.d("calculateRoute: destination is null, therefore, destination can't be set.")
+            return
+        }
+
+        val origin = Point(userLocation.longitude, userLocation.latitude)
+        if (org.maplibre.geojson.turf.TurfMeasurement.distance(origin, destination, TurfUnit.METRES) < 50) {
+            Timber.d("calculateRoute: distance < 50 m")
+            binding.startRouteButton.visibility = View.GONE
+            return
+        }
+
+        // The full GraphHopper API is documented here:
+        // https://docs.graphhopper.com/openapi/routing
+        val requestBody = mapOf(
+            "type" to "mapbox",
+            "profile" to "car",
+            "locale" to language,
+            "points" to listOf(
+                listOf(origin.longitude, origin.latitude),
+                listOf(destination.longitude, destination.latitude)
+            )
+        )
+
+        val requestBodyJson = Gson().toJson(requestBody)
+        val client = OkHttpClient()
+
+        // Create request object. Requires graphhopper_url to be set in developer-config.xml
+        val request = Request.Builder()
+            .header("User-Agent", "MapLibre Android Navigation SDK Demo App")
+            .url(getString(R.string.graphhopper_url) + "?key=" + getString(R.string.graphhopper_key))
+            .post(requestBodyJson.toRequestBody("application/json; charset=utf-8".toMediaType()))
+            .build()
+
+        Timber.d("calculateRoute enqueued requestBodyJson: %s", requestBodyJson)
+        client.newCall(request).enqueue(object : okhttp3.Callback {
+
+            override fun onFailure(call: okhttp3.Call, e: IOException) {
+                Timber.e(e, "calculateRoute Failed to get route from GraphHopperRouting")
+            }
+
+            override fun onResponse(call: okhttp3.Call, response: okhttp3.Response) {
+                response.use {
+                    if (response.isSuccessful) {
+                        Timber.e(
+                            "calculateRoute to GraphHopperRouting successful with status code: %s",
+                            response.code
+                        )
+                        val responseBodyJson = response.body!!.string()
+                        Timber.d(
+                            "calculateRoute GraphHopperRouting responseBodyJson: %s",
+                            responseBodyJson
+                        )
+                        val maplibreResponse = DirectionsResponse.fromJson(responseBodyJson);
+                        this@GraphHopperNavigationActivity.route = maplibreResponse.routes
+                            .first()
+                            .copy(
+                                routeOptions = RouteOptions(
+                                    // See ValhallaNavigationActivity why these dummy route options are necessary
+                                    baseUrl = "https://valhalla.routing",
+                                    profile = "valhalla",
+                                    user = "valhalla",
+                                    accessToken = "valhalla",
+                                    voiceInstructions = true,
+                                    bannerInstructions = true,
+                                    language = language,
+                                    coordinates = listOf(origin, destination),
+                                    requestUuid = "0000-0000-0000-0000"
+                                )
+                            )
+
+                        runOnUiThread {
+                            navigationMapRoute?.addRoutes(maplibreResponse.routes)
+                            binding.startRouteLayout.visibility = View.VISIBLE
+                        }
+                    } else {
+                        Timber.e(
+                            "calculateRoute Request to GraphHopper failed with status code: %s: %s",
+                            response.code,
+                            response.body
+                        )
+                    }
+                }
+            }
+        })
+    }
+
+    override fun onResume() {
+        super.onResume()
+        binding.mapView.onResume()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        binding.mapView.onPause()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        binding.mapView.onStart()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        binding.mapView.onStop()
+    }
+
+    override fun onLowMemory() {
+        super.onLowMemory()
+        binding.mapView.onLowMemory()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        if (::mapLibreMap.isInitialized) {
+            mapLibreMap.removeOnMapClickListener(this)
+        }
+        binding.mapView.onDestroy()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        binding.mapView.onSaveInstanceState(outState)
+    }
+}

--- a/app/src/main/java/org/maplibre/navigation/android/example/GraphHopperNavigationActivity.kt
+++ b/app/src/main/java/org/maplibre/navigation/android/example/GraphHopperNavigationActivity.kt
@@ -187,7 +187,7 @@ class GraphHopperNavigationActivity :
         // Create request object. Requires graphhopper_url to be set in developer-config.xml
         val request = Request.Builder()
             .header("User-Agent", "MapLibre Android Navigation SDK Demo App")
-            .url(getString(R.string.graphhopper_url) + "?key=" + getString(R.string.graphhopper_key))
+            .url(getString(R.string.graphhopper_url))
             .post(requestBodyJson.toRequestBody("application/json; charset=utf-8".toMediaType()))
             .build()
 

--- a/app/src/main/java/org/maplibre/navigation/android/example/MainActivity.java
+++ b/app/src/main/java/org/maplibre/navigation/android/example/MainActivity.java
@@ -49,6 +49,11 @@ public class MainActivity extends AppCompatActivity implements PermissionsListen
             ValhallaNavigationActivity.class
         ));
         list.add(new SampleItem(
+                getString(R.string.title_graphhopper_navigation),
+                getString(R.string.description_graphhopper_navigation),
+                GraphHopperNavigationActivity.class
+        ));
+        list.add(new SampleItem(
             getString(R.string.title_navigation_ui),
             getString(R.string.description_navigation_ui),
             NavigationUIActivity.class

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,9 @@
     <string name="title_valhalla_navigation">Valhalla Navigation</string>
     <string name="description_vallhalla_navigation">Use Valhalla routing server to generate directions.</string>
 
+    <string name="title_graphhopper_navigation">GraphHopper Navigation</string>
+    <string name="description_graphhopper_navigation">Use GraphHopper routing server to generate directions.</string>
+
     <string name="title_off_route_detection">Off route detection</string>
     <string name="description_off_route_detection">Uses the Route Utils class to determine if a users off route.</string>
 

--- a/gradle/developer-config.gradle
+++ b/gradle/developer-config.gradle
@@ -17,6 +17,9 @@ task accessToken {
                 "    <!-- Your valhalla url (example: https://valhalla1.openstreetmap.de/route) -->\n" +
                 "    <!-- Don't use the following server in production, it is for demonstration purposes only: -->\n" +
                 "    <string name=\"valhalla_url\" translatable=\"false\">https://valhalla1.openstreetmap.de/route</string>\n" +
+                "    <!-- Instead of valhalla you can use GraphHopper for the path finding. Example: https://graphhopper.com/api/1/navigate?key=YOUR_API_KEY or a local server -->\n" +
+                "    <!-- Don't use the following API key in production, it is for demonstration purposes only: -->\n" +
+                "    <string name=\"graphhopper_url\" translatable=\"false\">https://graphhopper.com/api/1/navigate?key=7088b84f-4cee-4059-96de-fd0cbda2fdff</string>\n" +
                 "    <!-- Your Mapbox access token (example: pk.abc...) -->\n" +
                 "    <string name=\"mapbox_access_token\" translatable=\"false\">" + mapboxAccessToken + "</string>\n" +
                 "    <!-- Map tile provider for light design (example: https://api.maptiler.com/maps/basic-v2/style.json?key=...) -->\n" +

--- a/sample/android/app/src/main/java/org/maplibre/navigation/sample/android/core/CoreOnlyFragment.kt
+++ b/sample/android/app/src/main/java/org/maplibre/navigation/sample/android/core/CoreOnlyFragment.kt
@@ -147,42 +147,62 @@ class CoreOnlyFragment : Fragment() {
     }
 
     private suspend fun fetchRoute(): DirectionsResponse = suspendCoroutine { continuation ->
-        val requestBody = mapOf(
-            "format" to "osrm",
-            "costing" to "auto",
-            "banner_instructions" to true,
-            "voice_instructions" to true,
-            "language" to "en-US",
-            "directions_options" to mapOf(
-                "units" to "kilometers"
-            ),
-            "costing_options" to mapOf(
-                "auto" to mapOf(
-                    "top_speed" to 130
+        val provider = "valhalla"
+
+        val requestBody = if provider == "graphhopper" {
+            mapOf(
+                "type" to "mapbox",
+                "profile" to "car",
+                "locale" to "en-US",
+                "points" to listOf(
+                    // Hannover, Germany
+                    listOf(9.6935451, 52.3758408),
+                    // Hamburg, Germany
+                    listOf(9.9769191, 53.5426183)
                 )
-            ),
-            "locations" to listOf(
-                // Hannover, Germany
-                mapOf(
-                    "lon" to 9.6935451,
-                    "lat" to 52.3758408,
-                    "type" to "break"
+                // flexible options possible via "custom_model"
+            )
+        } else {
+            mapOf(
+                "format" to "osrm",
+                "costing" to "auto",
+                "banner_instructions" to true,
+                "voice_instructions" to true,
+                "language" to "en-US",
+                "directions_options" to mapOf(
+                    "units" to "kilometers"
                 ),
-                // Hamburg, Germany
-                mapOf(
-                    "lon" to 9.9769191,
-                    "lat" to 53.5426183,
-                    "type" to "break"
+                "costing_options" to mapOf(
+                    "auto" to mapOf(
+                        "top_speed" to 130
+                    )
+                ),
+                "locations" to listOf(
+                    // Hannover, Germany
+                    mapOf(
+                        "lon" to 9.6935451,
+                        "lat" to 52.3758408,
+                        "type" to "break"
+                    ),
+                    // Hamburg, Germany
+                    mapOf(
+                        "lon" to 9.9769191,
+                        "lat" to 53.5426183,
+                        "type" to "break"
+                    )
                 )
             )
-        )
+        }
 
         val requestBodyJson = Gson().toJson(requestBody)
         val client = OkHttpClient()
 
+        val url = if (provider == "valhalla") "https://valhalla1.openstreetmap.de/route"
+            else "https://graphhopper.com/api/1/navigate/?key=YOUR_KEY"
+
         val request = Request.Builder()
             .header("User-Agent", "ML Nav - Android Sample App")
-            .url("https://valhalla1.openstreetmap.de/route")
+            .url(url)
             .post(requestBodyJson.toRequestBody("application/json; charset=utf-8".toMediaType()))
             .build()
 

--- a/sample/android/app/src/main/java/org/maplibre/navigation/sample/android/core/CoreOnlyFragment.kt
+++ b/sample/android/app/src/main/java/org/maplibre/navigation/sample/android/core/CoreOnlyFragment.kt
@@ -198,7 +198,7 @@ class CoreOnlyFragment : Fragment() {
         val client = OkHttpClient()
 
         val url = if (provider == "valhalla") "https://valhalla1.openstreetmap.de/route"
-            else "https://graphhopper.com/api/1/navigate/?key=YOUR_KEY"
+            else "https://graphhopper.com/api/1/navigate?key=7088b84f-4cee-4059-96de-fd0cbda2fdff"
 
         val request = Request.Builder()
             .header("User-Agent", "ML Nav - Android Sample App")


### PR DESCRIPTION
this adds a new graphhopper sample using the more powerful `POST /navigate` request. This is the same request format as `POST /route` but with the mapbox compatible response.

Also graphhopper can be used for the multiplatform sample via changing provider="valhalla" to "graphhopper".

Related to https://github.com/maplibre/maplibre-navigation-android/issues/151#issuecomment-2768852723

Not sure why the test / build fails here, but locally `./gradle clean build` is green.

(Please note that I'm not a good Android/Kotlin dev and let me know possible improvements :) )