### PR TITLE
Fallback for timed out GPS fix on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changelog for the MapLibre Navigation SDK for Android
 
 MapLibre welcomes participation and contributions from everyone.
 
+## Unreleased
+
+- Improve AppleLocationEngine time-out behavior [#176](https://github.com/maplibre/maplibre-navigation-android/pull/176)
+
 ### v5.0.0-pre9 - Jul 11, 2025
 
 - Update MapLibre native to v11.12.1

--- a/maplibre-navigation-core/src/iosMain/kotlin/org/maplibre/navigation/core/location/engine/AppleLocationEngine.kt
+++ b/maplibre-navigation-core/src/iosMain/kotlin/org/maplibre/navigation/core/location/engine/AppleLocationEngine.kt
@@ -89,11 +89,12 @@ open class AppleLocationEngine(private val getLocationTimeout: Duration, private
      * @return The current [Location] or null if unavailable or the timeout is exceeded.
      */
     private suspend fun getLocation(timeout: Duration): Location? = withContext(Dispatchers.Main) {
+        val locationManager = CLLocationManager().also {
+            it.allowsBackgroundLocationUpdates = enableBackgroundLocationUpdates
+        }
+
         withTimeoutOrNull(timeout) {
             suspendCancellableCoroutine { continuation ->
-                val locationManager = CLLocationManager().also {
-                    it.allowsBackgroundLocationUpdates = enableBackgroundLocationUpdates
-                }
                 locationManager.delegate = object : NSObject(), CLLocationManagerDelegateProtocol {
                     /**
                      * Called when the location manager updates the location.
@@ -139,7 +140,7 @@ open class AppleLocationEngine(private val getLocationTimeout: Duration, private
 
                 locationManager.requestLocation()
             }
-        }
+        } ?: locationManager.location?.toLocation()
     }
 
     /**

--- a/maplibre-navigation-core/src/iosMain/kotlin/org/maplibre/navigation/core/location/engine/AppleLocationEngine.kt
+++ b/maplibre-navigation-core/src/iosMain/kotlin/org/maplibre/navigation/core/location/engine/AppleLocationEngine.kt
@@ -95,7 +95,7 @@ open class AppleLocationEngine(private val getLocationTimeout: Duration, private
 
         withTimeoutOrNull(timeout) {
             suspendCancellableCoroutine { continuation ->
-                locationManager.delegate = object : NSObject(), CLLocationManagerDelegateProtocol {
+                val delegate = object : NSObject(), CLLocationManagerDelegateProtocol {
                     /**
                      * Called when the location manager updates the location.
                      *
@@ -138,6 +138,7 @@ open class AppleLocationEngine(private val getLocationTimeout: Duration, private
                     locationManager.delegate = null
                 }
 
+                locationManager.delegate = delegate
                 locationManager.requestLocation()
             }
         } ?: locationManager.location?.toLocation()


### PR DESCRIPTION
### Changeset

- If a `getLastLocation` request times out on iOS, make a last resort attempt to retrieve the location directly from the `CLLocationManager` instance
- Store the delegate instance in a value to prevent its deallocation