### PR TITLE
do not crash demo for GraphHopper rerouting

### DIFF
--- a/app/src/main/java/org/maplibre/navigation/android/example/GraphHopperNavigationActivity.kt
+++ b/app/src/main/java/org/maplibre/navigation/android/example/GraphHopperNavigationActivity.kt
@@ -187,7 +187,7 @@ class GraphHopperNavigationActivity :
         // Create request object. Requires graphhopper_url to be set in developer-config.xml
         val request = Request.Builder()
             .header("User-Agent", "MapLibre Android Navigation SDK Demo App")
-            .url(getString(R.string.graphhopper_url))
+            .url(getString(R.string.graphhopper_url) + "?key=" + getString(R.string.graphhopper_key))
             .post(requestBodyJson.toRequestBody("application/json; charset=utf-8".toMediaType()))
             .build()
 
@@ -215,11 +215,12 @@ class GraphHopperNavigationActivity :
                             .first()
                             .copy(
                                 routeOptions = RouteOptions(
-                                    // See ValhallaNavigationActivity why these dummy route options are necessary
-                                    baseUrl = "https://valhalla.routing",
-                                    profile = "valhalla",
-                                    user = "valhalla",
-                                    accessToken = "valhalla",
+                                    // Used for rerouting. See ValhallaNavigationActivity.
+                                    // TODO: problematic as not the original POST request is used, see #168
+                                    baseUrl = getString(R.string.graphhopper_url),
+                                    profile = "car",
+                                    user = "gh",
+                                    accessToken = "pk." + getString(R.string.graphhopper_key),
                                     voiceInstructions = true,
                                     bannerInstructions = true,
                                     language = language,

--- a/app/src/main/java/org/maplibre/navigation/android/example/GraphHopperNavigationActivity.kt
+++ b/app/src/main/java/org/maplibre/navigation/android/example/GraphHopperNavigationActivity.kt
@@ -215,7 +215,7 @@ class GraphHopperNavigationActivity :
                             .first()
                             .copy(
                                 routeOptions = RouteOptions(
-                                    // Used for rerouting. See ValhallaNavigationActivity.
+                                    // Used for rerouting. See #201.
                                     // TODO: problematic as not the original POST request is used, see #168
                                     baseUrl = getString(R.string.graphhopper_url),
                                     profile = "car",

--- a/gradle/developer-config.gradle
+++ b/gradle/developer-config.gradle
@@ -17,10 +17,10 @@ task accessToken {
                 "    <!-- Your valhalla url (example: https://valhalla1.openstreetmap.de/route) -->\n" +
                 "    <!-- Don't use the following server in production, it is for demonstration purposes only: -->\n" +
                 "    <string name=\"valhalla_url\" translatable=\"false\">https://valhalla1.openstreetmap.de/route</string>\n" +
-                "    <!-- Instead of valhalla you can use GraphHopper for the path finding. -->\n" +
+                "    <!-- Instead of valhalla you can use GraphHopper for the path finding. Note that the graphhopper_url has to end with '/'. (#201) -->\n" +
                 "    <!-- Don't use the following API key in production, it is for demonstration purposes only: -->\n" +
-                "    <!-- <string name=\"graphhopper_key\" translatable=\"false\">7088b84f-4cee-4059-96de-fd0cbda2fdff</string> -->\n" +
-                "    <!-- <string name=\"graphhopper_url\" translatable=\"false\">https://graphhopper.com/api/1/navigate/</string> -->\n" +
+                "    <string name=\"graphhopper_key\" translatable=\"false\">7088b84f-4cee-4059-96de-fd0cbda2fdff</string>\n" +
+                "    <string name=\"graphhopper_url\" translatable=\"false\">https://graphhopper.com/api/1/navigate/</string>\n" +
                 "    <!-- Your Mapbox access token (example: pk.abc...) -->\n" +
                 "    <string name=\"mapbox_access_token\" translatable=\"false\">" + mapboxAccessToken + "</string>\n" +
                 "    <!-- Map tile provider for light design (example: https://api.maptiler.com/maps/basic-v2/style.json?key=...) -->\n" +

--- a/gradle/developer-config.gradle
+++ b/gradle/developer-config.gradle
@@ -17,9 +17,10 @@ task accessToken {
                 "    <!-- Your valhalla url (example: https://valhalla1.openstreetmap.de/route) -->\n" +
                 "    <!-- Don't use the following server in production, it is for demonstration purposes only: -->\n" +
                 "    <string name=\"valhalla_url\" translatable=\"false\">https://valhalla1.openstreetmap.de/route</string>\n" +
-                "    <!-- Instead of valhalla you can use GraphHopper for the path finding. Example: https://graphhopper.com/api/1/navigate?key=YOUR_API_KEY or a local server -->\n" +
+                "    <!-- Instead of valhalla you can use GraphHopper for the path finding. -->\n" +
                 "    <!-- Don't use the following API key in production, it is for demonstration purposes only: -->\n" +
-                "    <string name=\"graphhopper_url\" translatable=\"false\">https://graphhopper.com/api/1/navigate?key=7088b84f-4cee-4059-96de-fd0cbda2fdff</string>\n" +
+                "    <!-- <string name=\"graphhopper_key\" translatable=\"false\">7088b84f-4cee-4059-96de-fd0cbda2fdff</string> -->\n" +
+                "    <!-- <string name=\"graphhopper_url\" translatable=\"false\">https://graphhopper.com/api/1/navigate/</string> -->\n" +
                 "    <!-- Your Mapbox access token (example: pk.abc...) -->\n" +
                 "    <string name=\"mapbox_access_token\" translatable=\"false\">" + mapboxAccessToken + "</string>\n" +
                 "    <!-- Map tile provider for light design (example: https://api.maptiler.com/maps/basic-v2/style.json?key=...) -->\n" +


### PR DESCRIPTION
This change avoids the GraphHopper demo app crash when rerouting, i.e. fixes #168. 

However, a potential different request is used for the GET request compared to the initial POST request, which is a general problem also for ValhallaNavigationActivity.

Note that the baseUrl (and so also graphhopper_url) has to end with '/'. Maybe this should be added in the comment of the developer xml config?