### PR TITLE
fix: wrong rotation direction for replay

### DIFF
--- a/maplibre-navigation-core/src/commonMain/kotlin/org/maplibre/navigation/core/location/replay/ReplayRouteLocationConverter.kt
+++ b/maplibre-navigation-core/src/commonMain/kotlin/org/maplibre/navigation/core/location/replay/ReplayRouteLocationConverter.kt
@@ -7,6 +7,7 @@ import org.maplibre.navigation.core.models.DirectionsRoute
 import org.maplibre.navigation.core.utils.Constants
 import org.maplibre.geojson.turf.TurfMeasurement
 import org.maplibre.geojson.turf.TurfUnit
+import org.maplibre.navigation.core.utils.MathUtils.wrap
 import org.maplibre.navigation.core.utils.getCurrentSystemTimeSeconds
 
 open class ReplayRouteLocationConverter(
@@ -75,7 +76,10 @@ open class ReplayRouteLocationConverter(
             mockedLocations.add(
                 if (i - 1 >= 0) {
                     val bearing = TurfMeasurement.bearing(points[i - 1], points[i])
-                    mockedLocation.copy(bearing = bearing.toFloat())
+                    mockedLocation.copy(bearing = wrap(bearing, 0.0, 360.0).toFloat())
+                } else if (points.size > 1) {
+                    val bearing = TurfMeasurement.bearing(points[0], points[1])
+                    mockedLocation.copy(bearing = wrap(bearing, 0.0, 360.0).toFloat())
                 } else {
                     mockedLocation.copy(bearing = 0f)
                 }


### PR DESCRIPTION
This fixes #214. 

I told claude to do a research and told it that before a similar issue existed when a coordinate was duplicate and this is what it found

> fix: wrap replay bearing to [0, 360) and compute first-point bearing TurfMeasurement.bearing() returns [-180, 180] but Android Location expects [0, 360). Apply MathUtils.wrap() consistent with SnapToRoute. Also derive first point bearing from route direction instead of hardcoding 0 (north).

besides some other issues (I'm investigating).

And this small change indeed fixes the incorrect rotation direction. However, at certain junctions the rotation is still not always correct and sometimes looks like if the animation is skipped (but this is also a problem in main branch so IMO not an issue of the fix).