### PR TITLE
Add leg notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ MapLibre welcomes participation and contributions from everyone.
 
 ## Unreleased
 
+- Add notification property to `RouteLeg` [#230](https://github.com/maplibre/maplibre-navigation-android/pull/230)
+
 ### v5.0.0-pre14 - Jun 19, 2026
 
 - **BREAKING**: The library is now based on Spatial-K instead of the WIP state of [maplibre-java](https://github.com/maplibre/maplibre-java/pull/40)

--- a/maplibre-navigation-core/src/androidUnitTest/kotlin/org/maplibre/navigation/core/models/NotificationTest.kt
+++ b/maplibre-navigation-core/src/androidUnitTest/kotlin/org/maplibre/navigation/core/models/NotificationTest.kt
@@ -41,7 +41,7 @@ class NotificationTest {
             """.trimIndent()
         )
 
-        val notification = routeLeg.notifications.single()
+        val notification = routeLeg.notifications!!.single()
         assertEquals(NotificationType.Violation, notification.type)
         assertEquals(NotificationType.Subtype.MaxWidth, notification.subtype)
         assertEquals(NotificationRefreshType.Static, notification.refreshType)
@@ -81,7 +81,7 @@ class NotificationTest {
             """.trimIndent()
         )
 
-        val pointNotification = routeLeg.notifications[0]
+        val pointNotification = routeLeg.notifications!![0]
         assertEquals(NotificationType.Alert, pointNotification.type)
         assertEquals(NotificationType.Subtype.CountryBorderCrossing, pointNotification.subtype)
         assertEquals(NotificationRefreshType.Dynamic, pointNotification.refreshType)
@@ -137,12 +137,12 @@ class NotificationTest {
     }
 
     @Test
-    fun routeLeg_fromJson_withoutNotifications_returnsEmptyList() {
+    fun routeLeg_fromJson_withoutNotifications_returnsNull() {
         val routeLeg = json.decodeFromString<RouteLeg>(
             """{"distance":100.0,"duration":10.0,"steps":[]}"""
         )
 
-        assertEquals(emptyList(), routeLeg.notifications)
+        assertNull(routeLeg.notifications)
     }
 
     @Test

--- a/maplibre-navigation-core/src/androidUnitTest/kotlin/org/maplibre/navigation/core/models/NotificationTest.kt
+++ b/maplibre-navigation-core/src/androidUnitTest/kotlin/org/maplibre/navigation/core/models/NotificationTest.kt
@@ -1,0 +1,187 @@
+package org.maplibre.navigation.core.models
+
+import kotlinx.serialization.SerializationException
+import org.maplibre.navigation.core.json
+import org.maplibre.navigation.core.models.notification.Notification
+import org.maplibre.navigation.core.models.notification.NotificationDetails
+import org.maplibre.navigation.core.models.notification.NotificationRefreshType
+import org.maplibre.navigation.core.models.notification.NotificationType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+class NotificationTest {
+
+    @Test
+    fun routeLeg_fromJson_deserializesNotifications() {
+        val routeLeg = json.decodeFromString<RouteLeg>(
+            """
+            {
+              "distance": 100.0,
+              "duration": 10.0,
+              "steps": [],
+              "notifications": [
+                {
+                  "type": "violation",
+                  "subtype": "maxWidth",
+                  "refresh_type": "static",
+                  "geometry_index": 5,
+                  "geometry_index_start": 4,
+                  "geometry_index_end": 6,
+                  "details": {
+                    "requested_value": "3",
+                    "actual_value": "2.5",
+                    "unit": "m",
+                    "message": "Width restriction"
+                  }
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+
+        val notification = routeLeg.notifications.single()
+        assertEquals(NotificationType.Violation, notification.type)
+        assertEquals(NotificationType.Subtype.MaxWidth, notification.subtype)
+        assertEquals(NotificationRefreshType.Static, notification.refreshType)
+        assertEquals(5, notification.geometryIndex)
+        assertEquals(4, notification.startIndex)
+        assertEquals(6, notification.endIndex)
+        assertEquals("3", notification.details?.requestedValue)
+        assertEquals("2.5", notification.details?.actualValue)
+        assertEquals("m", notification.details?.unit)
+        assertEquals("Width restriction", notification.details?.message)
+    }
+
+    @Test
+    fun routeLeg_fromJson_deserializesPointAndRangeNotifications() {
+        val routeLeg = json.decodeFromString<RouteLeg>(
+            """
+            {
+              "distance": 100.0,
+              "duration": 10.0,
+              "steps": [],
+              "notifications": [
+                {
+                  "type": "alert",
+                  "subtype": "countryBorderCrossing",
+                  "refresh_type": "dynamic",
+                  "geometry_index": 7
+                },
+                {
+                  "type": "violation",
+                  "subtype": "ferry",
+                  "refresh_type": "static",
+                  "geometry_index_start": 10,
+                  "geometry_index_end": 15
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+
+        val pointNotification = routeLeg.notifications[0]
+        assertEquals(NotificationType.Alert, pointNotification.type)
+        assertEquals(NotificationType.Subtype.CountryBorderCrossing, pointNotification.subtype)
+        assertEquals(NotificationRefreshType.Dynamic, pointNotification.refreshType)
+        assertEquals(7, pointNotification.geometryIndex)
+        assertNull(pointNotification.startIndex)
+        assertNull(pointNotification.endIndex)
+        assertNull(pointNotification.details)
+
+        val rangeNotification = routeLeg.notifications[1]
+        assertEquals(NotificationType.Violation, rangeNotification.type)
+        assertEquals(NotificationType.Subtype.Ferry, rangeNotification.subtype)
+        assertEquals(NotificationRefreshType.Static, rangeNotification.refreshType)
+        assertNull(rangeNotification.geometryIndex)
+        assertEquals(10, rangeNotification.startIndex)
+        assertEquals(15, rangeNotification.endIndex)
+    }
+
+    @Test
+    fun notification_fromJson_preservesUnknownValuesForForwardCompatibility() {
+        val notification = json.decodeFromString<Notification>(
+            """{"type":"newType","subtype":"newSubtype","refresh_type":"newRefreshType"}"""
+        )
+
+        assertEquals(NotificationType("newType"), notification.type)
+        assertEquals(NotificationType.Subtype("newSubtype"), notification.subtype)
+        assertEquals(NotificationRefreshType("newRefreshType"), notification.refreshType)
+    }
+
+    @Test
+    fun notification_fromJson_requiresTypeAndRefreshType() {
+        assertFailsWith<SerializationException> {
+            json.decodeFromString<Notification>("""{"refresh_type":"static"}""")
+        }
+        assertFailsWith<SerializationException> {
+            json.decodeFromString<Notification>("""{"type":"alert"}""")
+        }
+    }
+
+    @Test
+    fun notification_fromJson_allowsMessageOnlyDetailsAndNoSubtype() {
+        val notification = json.decodeFromString<Notification>(
+            """{"type":"alert","refresh_type":"dynamic","details":{"message":"Ferry service unavailable"}}"""
+        )
+
+        assertNull(notification.subtype)
+        assertNull(notification.geometryIndex)
+        assertNull(notification.startIndex)
+        assertNull(notification.endIndex)
+        assertNull(notification.details?.requestedValue)
+        assertNull(notification.details?.actualValue)
+        assertNull(notification.details?.unit)
+        assertEquals("Ferry service unavailable", notification.details?.message)
+    }
+
+    @Test
+    fun routeLeg_fromJson_withoutNotifications_returnsEmptyList() {
+        val routeLeg = json.decodeFromString<RouteLeg>(
+            """{"distance":100.0,"duration":10.0,"steps":[]}"""
+        )
+
+        assertEquals(emptyList(), routeLeg.notifications)
+    }
+
+    @Test
+    fun routeLeg_builderAndToBuilder_preserveNotifications() {
+        val notification = Notification(
+            type = NotificationType.Alert,
+            subtype = NotificationType.Subtype.Ferry,
+            refreshType = NotificationRefreshType.Static,
+        )
+        val routeLeg = RouteLeg.Builder(
+            distance = 100.0,
+            duration = 10.0,
+            steps = emptyList()
+        ).withNotifications(listOf(notification)).build()
+
+        assertEquals(listOf(notification), routeLeg.notifications)
+        assertEquals(routeLeg, routeLeg.toBuilder().build())
+    }
+
+    @Test
+    fun notification_toJson_usesDirectionsWireNames() {
+        val notification = Notification(
+            type = NotificationType.Violation,
+            refreshType = NotificationRefreshType.Dynamic,
+            geometryIndex = 5,
+            startIndex = 4,
+            endIndex = 6,
+            details = NotificationDetails(
+                requestedValue = "3",
+                actualValue = "2.5",
+            )
+        )
+
+        val serialized = json.encodeToString(notification)
+
+        assertEquals(
+            """{"type":"violation","refresh_type":"dynamic","geometry_index":5,"geometry_index_start":4,"geometry_index_end":6,"details":{"requested_value":"3","actual_value":"2.5"}}""",
+            serialized
+        )
+        assertNull(notification.subtype)
+    }
+}

--- a/maplibre-navigation-core/src/commonMain/kotlin/org/maplibre/navigation/core/models/RouteLeg.kt
+++ b/maplibre-navigation-core/src/commonMain/kotlin/org/maplibre/navigation/core/models/RouteLeg.kt
@@ -90,7 +90,7 @@ data class RouteLeg(
     /**
      * A list of notifications that are relevant to this leg
      * */
-    val notifications: List<Notification> = emptyList(),
+    val notifications: List<Notification>? = null,
 ) {
 
     /**
@@ -129,7 +129,7 @@ data class RouteLeg(
         private var incidents: List<Incident>? = null
         private var annotation: LegAnnotation? = null
         private var closures: List<Closure>? = null
-        private var notifications: List<Notification> = emptyList()
+        private var notifications: List<Notification>? = null
 
         /**
          * Sets the typical duration.
@@ -186,7 +186,7 @@ data class RouteLeg(
          * @param notifications The notifications.
          * @return The builder instance.
          */
-        fun withNotifications(notifications: List<Notification>) =
+        fun withNotifications(notifications: List<Notification>?) =
             apply { this.notifications = notifications }
 
         /**

--- a/maplibre-navigation-core/src/commonMain/kotlin/org/maplibre/navigation/core/models/RouteLeg.kt
+++ b/maplibre-navigation-core/src/commonMain/kotlin/org/maplibre/navigation/core/models/RouteLeg.kt
@@ -2,6 +2,7 @@ package org.maplibre.navigation.core.models
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import org.maplibre.navigation.core.models.notification.Notification
 
 /**
  * A route between only two [DirectionsWaypoint].
@@ -85,6 +86,11 @@ data class RouteLeg(
      * @return a list of [Incident]
      */
     val closures: List<Closure>? = null,
+
+    /**
+     * A list of notifications that are relevant to this leg
+     * */
+    val notifications: List<Notification> = emptyList(),
 ) {
 
     /**
@@ -102,6 +108,7 @@ data class RouteLeg(
             withIncidents(incidents)
             withAnnotation(annotation)
             withClosures(closures)
+            withNotifications(notifications)
         }
     }
 
@@ -122,6 +129,7 @@ data class RouteLeg(
         private var incidents: List<Incident>? = null
         private var annotation: LegAnnotation? = null
         private var closures: List<Closure>? = null
+        private var notifications: List<Notification> = emptyList()
 
         /**
          * Sets the typical duration.
@@ -129,7 +137,8 @@ data class RouteLeg(
          * @param durationTypical The typical duration.
          * @return The builder instance.
          */
-        fun withDurationTypical(durationTypical: Double?) = apply { this.durationTypical = durationTypical }
+        fun withDurationTypical(durationTypical: Double?) =
+            apply { this.durationTypical = durationTypical }
 
         /**
          * Sets the summary.
@@ -172,6 +181,15 @@ data class RouteLeg(
         fun withClosures(closures: List<Closure>?) = apply { this.closures = closures }
 
         /**
+         * Sets the notifications.
+         *
+         * @param notifications The notifications.
+         * @return The builder instance.
+         */
+        fun withNotifications(notifications: List<Notification>) =
+            apply { this.notifications = notifications }
+
+        /**
          * Builds a `RouteLeg` instance with the current builder values.
          *
          * @return A new `RouteLeg` instance.
@@ -186,7 +204,8 @@ data class RouteLeg(
                 admins = admins,
                 incidents = incidents,
                 annotation = annotation,
-                closures = closures
+                closures = closures,
+                notifications = notifications
             )
         }
     }

--- a/maplibre-navigation-core/src/commonMain/kotlin/org/maplibre/navigation/core/models/notification/Notification.kt
+++ b/maplibre-navigation-core/src/commonMain/kotlin/org/maplibre/navigation/core/models/notification/Notification.kt
@@ -1,0 +1,51 @@
+package org.maplibre.navigation.core.models.notification
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * A notification that is relevant to a route leg.
+ * According to Mapbox Navigation Notifications API spec [Mapbox Docs](https://docs.mapbox.com/api/navigation/directions/#notification-object)
+ * */
+@Serializable
+data class Notification(
+    /**
+     * The type of notifications. Notification types supported are violation and alert.
+     * */
+    val type: NotificationType,
+
+    /**
+     * The optional subtype of notification.
+     * */
+    val subtype: NotificationType.Subtype? = null,
+
+    /**
+     * The refresh type of notification to distinguish between static and dynamic notifications.
+     * */
+    @SerialName("refresh_type")
+    val refreshType: NotificationRefreshType,
+
+    /**
+     * The optional position in the coordinate list where the notification occurred, relative to the start of the leg it's on.
+     * */
+    @SerialName("geometry_index")
+    val geometryIndex: Int? = null,
+
+    /**
+     * The optional position in the coordinate list where the notification began, relative to the start of the leg it's on.
+     * */
+    @SerialName("geometry_index_start")
+    val startIndex: Int? = null,
+
+    /**
+     * The optional position in the coordinate list where the notification ended, relative to the start of the leg it's on.
+     * */
+    @SerialName("geometry_index_end")
+    val endIndex: Int? = null,
+
+    /**
+     * 	The optional details specific to the notification type and subtype.
+     * */
+    val details: NotificationDetails? = null
+)
+

--- a/maplibre-navigation-core/src/commonMain/kotlin/org/maplibre/navigation/core/models/notification/NotificationDetails.kt
+++ b/maplibre-navigation-core/src/commonMain/kotlin/org/maplibre/navigation/core/models/notification/NotificationDetails.kt
@@ -1,0 +1,26 @@
+package org.maplibre.navigation.core.models.notification
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NotificationDetails(
+    /**
+     * The optional requested value in the request. For example, it is 3 (meters) if we specify `max_width=3` in the request.
+     * */
+    @SerialName("requested_value")
+    val requestedValue: String? = null,
+    /**
+     * The optional actual value associated with the property of the road. For example, it is 2.5 (meters) if maximum road width is 2.5 meters.
+     * */
+    @SerialName("actual_value")
+    val actualValue: String? = null,
+    /**
+     * The optional unit of measure associated with `details.actual_value` and `details.requested_value`.
+     * */
+    val unit: String? = null,
+    /**
+     * The optional message associated with the notification.
+     * */
+    val message: String? = null,
+)

--- a/maplibre-navigation-core/src/commonMain/kotlin/org/maplibre/navigation/core/models/notification/NotificationReason.kt
+++ b/maplibre-navigation-core/src/commonMain/kotlin/org/maplibre/navigation/core/models/notification/NotificationReason.kt
@@ -1,0 +1,16 @@
+package org.maplibre.navigation.core.models.notification
+
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmInline
+
+/***
+ * The reason why notification was issued.
+ * */
+@Serializable
+@JvmInline
+value class NotificationReason(val value: String) {
+    companion object {
+        val OutOfOrder = NotificationReason("outOfOrder")
+        val Occupied = NotificationReason("occupied")
+    }
+}

--- a/maplibre-navigation-core/src/commonMain/kotlin/org/maplibre/navigation/core/models/notification/NotificationRefreshType.kt
+++ b/maplibre-navigation-core/src/commonMain/kotlin/org/maplibre/navigation/core/models/notification/NotificationRefreshType.kt
@@ -1,0 +1,16 @@
+package org.maplibre.navigation.core.models.notification
+
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmInline
+
+/**
+ * The refresh type of notification to distinguish between static and dynamic notifications.
+ * */
+@Serializable
+@JvmInline
+value class NotificationRefreshType(val value: String) {
+    companion object {
+        val Static = NotificationRefreshType("static")
+        val Dynamic = NotificationRefreshType("dynamic")
+    }
+}

--- a/maplibre-navigation-core/src/commonMain/kotlin/org/maplibre/navigation/core/models/notification/NotificationType.kt
+++ b/maplibre-navigation-core/src/commonMain/kotlin/org/maplibre/navigation/core/models/notification/NotificationType.kt
@@ -1,0 +1,82 @@
+package org.maplibre.navigation.core.models.notification
+
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmInline
+
+/**
+ * The type of notifications. Notification types supported are `violation` and `alert`.
+ * `violation` is more severe in nature and are delivered when
+ * user-set parameters (ex: `exclude=unpaved`) are violated during route generation.
+ *
+ *
+ * The severity of `alert` is less, and is intended to inform users when implicit preferences cannot
+ * be satisfied (ex: `countryBorderCrossing`)
+ * */
+@Serializable
+@JvmInline
+value class NotificationType(val value: String) {
+    companion object {
+        /**
+         * Alert that is relevant to a route leg.
+         * */
+        val Alert = NotificationType("alert")
+
+        /**
+         * RouteLeg violates a restriction.
+         * */
+        val Violation = NotificationType("violation")
+    }
+    /**
+     * The optional subtype of notification
+     * */
+    @Serializable
+    @JvmInline
+    value class Subtype(val value: String) {
+        companion object {
+            /**
+             * `type=violation`-> The height of the vehicle is greater than the allowed height of the road. It is provided when max_height is specified.
+             * */
+            val MaxHeight = Subtype("maxHeight")
+            /**
+             * `type=violation`-> The width of the vehicle is greater than the allowed width of the road. It is provided when max_width is specified.
+             * */
+            val MaxWidth = Subtype("maxWidth")
+            /**
+             * `type=violation`-> The weight of the vehicle is greater than the allowed weight of the road. It is provided when max_weight is specified.
+             * */
+            val MaxWeight = Subtype("maxWeight")
+            /**
+             * `type=violation`-> Unpaved road, while it was explicitly requested to exclude unpaved roads from the route. It is provided when exclude=unpaved
+             * */
+            val Unpaved = Subtype("unpaved")
+            /**
+             * `type=violation`-> Road with tunnel, while it was explicitly requested to exclude tunnel roads from the route. It is provided when exclude=tunnel
+             * `type=alert`-> Indicates a tunnel is on route.
+             * */
+            val Tunnel = Subtype("tunnel")
+            /**
+             * `type=violation`-> Toll road, while it was explicitly requested to exclude toll roads from the route. It is provided when exclude=toll.
+             * `type=alert`-> Indicates a toll road is on route.
+             * */
+            val Toll = Subtype("toll")
+            /**
+             * `type=violation`-> Undesirable road, while it was explicitly requested to exclude a road from the route by point. It is provided when exclude=point(longitude latitude).
+             * */
+            val PointExclusion = Subtype("pointExclusion")
+            /**
+             * `type=violation`-> Indicates a country border crossing. It is provided when exclude=country_border.
+             * `type=alert`-> Indicates a country border crossing.
+             * */
+            val CountryBorderCrossing = Subtype("countryBorderCrossing")
+            /**
+             * `type=violation`-> Indicates a state border crossing. It is provided when exclude=state_border.
+             * `type=alert`-> Indicates a state border crossing.
+             * */
+            val StateBorderCrossing = Subtype("stateBorderCrossing")
+            /**
+             * `type=violation`-> Indicates a ferry crossing. It is provided when exclude=ferry.
+             * */
+            val Ferry = Subtype("ferry")
+        }
+    }
+}


### PR DESCRIPTION
### Description of PR
In this PR we are adding notifications to route legs. These offer us the possibility to warn drives of potential risks on their route. These notifications are implemented in accordance with the Mapbox spec outlined [here](https://docs.mapbox.com/api/navigation/directions/#notification-object).

### Why
At Flitsmeister we are looking to implement ferry notifications in our routing module. At the moment the DirectionsRoute object does not know how to parse said ferry notifications, so we could either parse the raw json ourselves and hack some way around it, or we could add it to the DirectionsRoute object as an expansion. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for route-leg notifications, including alerts, violations, refresh behavior, subtypes, and notification details.
  * Added notification metadata for geometry ranges, requested and actual values, units, and messages.
  * Added predefined notification types, subtypes, refresh modes, and common notification reasons.
  * Notifications are preserved through route-leg builders and default to an empty list when unavailable.

* **Tests**
  * Added coverage for notification parsing, serialization, validation, defaults, and forward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->